### PR TITLE
Feature/recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,6 +2882,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kate-recovery"
+version = "0.1.0"
+dependencies = [
+ "dusk-plonk",
+]
+
+[[package]]
 name = "kate-rpc-runtime-api"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2872,6 +2887,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parity-scale-codec",
+ "proptest",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.5.1",
@@ -5197,6 +5213,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
 name = "prost"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5402,6 +5438,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -5668,6 +5713,18 @@ dependencies = [
  "rustls",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -8505,6 +8562,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,6 +2867,7 @@ dependencies = [
  "frame-support",
  "getrandom 0.2.4",
  "hex",
+ "kate-recovery",
  "log",
  "num_cpus",
  "once_cell",
@@ -2885,7 +2886,10 @@ dependencies = [
 name = "kate-recovery"
 version = "0.1.0"
 dependencies = [
+ "dusk-bytes",
  "dusk-plonk",
+ "getrandom 0.2.4",
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
 	"kate",
+	"kate/recovery",
 	"primitives",
 	"pallets/executive",
 	"pallets/system",

--- a/kate/Cargo.toml
+++ b/kate/Cargo.toml
@@ -33,6 +33,7 @@ frame-support = { version = "4.0.0-dev", default-features = false }
 
 [dev-dependencies]
 test-case = "1.2.3"
+proptest = "1.0.0"
 
 [features]
 default = ["std"]

--- a/kate/Cargo.toml
+++ b/kate/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 da-primitives = { path = "../primitives", default-features = false }
+kate-recovery = { path = "recovery", default-features = true }
 
 # Others
 dusk-plonk = { version = "0.8.2", default-features = false, optional = true }

--- a/kate/recovery/Cargo.toml
+++ b/kate/recovery/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Denis Ermolin <denis.ermolin@matic.network>"]
 edition = "2018"
 
 [dependencies]
-dusk-plonk = { version = "0.8.2", default-features = false, optional = true }
+dusk-plonk = { version = "0.8.2" }

--- a/kate/recovery/Cargo.toml
+++ b/kate/recovery/Cargo.toml
@@ -5,20 +5,9 @@ authors = ["Denis Ermolin <denis.ermolin@matic.network>"]
 edition = "2018"
 
 [dependencies]
-dusk-plonk = { version = "0.8.2", default-features = false, features = ["std", "alloc"] }
-dusk-bytes = { version = "0.1.5", default-features = false, optional = true }
-getrandom = { version = "0.2", features = ["js"], optional = true }
+dusk-plonk =  {git = "https://github.com/maticnetwork/plonk.git", tag = "v0.8.2-polygon-2"}
+dusk-bytes = { version = "0.1.5"}
+getrandom = { version = "0.2", features = ["js"]}
 
 [dev-dependencies]
 rand = { version = "0.8.4" }
-
-[features]
-default = ["std"]
-alloc = ["dusk-plonk/alloc"]
-
-std = [
-	"dusk-plonk/std",
-    "dusk-bytes",
-    "getrandom/std",
-    "getrandom",
-]

--- a/kate/recovery/Cargo.toml
+++ b/kate/recovery/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Denis Ermolin <denis.ermolin@matic.network>"]
 edition = "2018"
 
 [dependencies]
-dusk-plonk = { version = "0.8.2", default-features = false, optional = true }
+dusk-plonk = { version = "0.8.2", default-features = false, features = ["std", "alloc"] }
 dusk-bytes = { version = "0.1.5", default-features = false, optional = true }
 getrandom = { version = "0.2", features = ["js"], optional = true }
 

--- a/kate/recovery/Cargo.toml
+++ b/kate/recovery/Cargo.toml
@@ -5,4 +5,19 @@ authors = ["Denis Ermolin <denis.ermolin@matic.network>"]
 edition = "2018"
 
 [dependencies]
-dusk-plonk = { version = "0.8.2" }
+dusk-plonk = { version = "0.8.2", default-features = false, optional = true }
+getrandom = { version = "0.2", features = ["js"], optional = true }
+
+[dev-dependencies]
+dusk-bytes = { version = "0.1.5" }
+rand = { version = "0.8.4" }
+
+[features]
+default = ["std"]
+alloc = ["dusk-plonk/alloc"]
+
+std = [
+	"dusk-plonk/std",
+    "getrandom/std",
+    "getrandom",
+]

--- a/kate/recovery/Cargo.toml
+++ b/kate/recovery/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "kate-recovery"
+version = "0.1.0"
+authors = ["Denis Ermolin <denis.ermolin@matic.network>"]
+edition = "2018"
+
+[dependencies]
+dusk-plonk = { version = "0.8.2", default-features = false, optional = true }

--- a/kate/recovery/Cargo.toml
+++ b/kate/recovery/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 
 [dependencies]
 dusk-plonk = { version = "0.8.2", default-features = false, optional = true }
+dusk-bytes = { version = "0.1.5", default-features = false, optional = true }
 getrandom = { version = "0.2", features = ["js"], optional = true }
 
 [dev-dependencies]
-dusk-bytes = { version = "0.1.5" }
 rand = { version = "0.8.4" }
 
 [features]
@@ -18,6 +18,7 @@ alloc = ["dusk-plonk/alloc"]
 
 std = [
 	"dusk-plonk/std",
+    "dusk-bytes",
     "getrandom/std",
     "getrandom",
 ]

--- a/kate/recovery/src/com.rs
+++ b/kate/recovery/src/com.rs
@@ -1,0 +1,425 @@
+use dusk_plonk::{fft::EvaluationDomain, prelude::BlsScalar};
+
+// This module is taken from https://gist.github.com/itzmeanjan/4acf9338d9233e79cfbee5d311e7a0b4
+// which I wrote few months back when exploring polynomial based erasure coding technique !
+
+pub fn reconstruct_poly(
+	// domain I'm working with
+	// all (i)ffts to be performed on it
+	eval_domain: EvaluationDomain,
+	// subset of available data
+	subset: Vec<Option<BlsScalar>>,
+) -> Result<Vec<BlsScalar>, String> {
+	let mut missing_indices = Vec::new();
+	for i in 0..subset.len() {
+		if let None = subset[i] {
+			missing_indices.push(i as u64);
+		}
+	}
+	let (mut zero_poly, zero_eval) =
+		zero_poly_fn(eval_domain, &missing_indices[..], subset.len() as u64);
+	for i in 0..subset.len() {
+		if let None = subset[i] {
+			if !(zero_eval[i] == BlsScalar::zero()) {
+				return Err("bad zero poly evaluation !".to_owned());
+			}
+		}
+	}
+	let mut poly_evals_with_zero: Vec<BlsScalar> = Vec::new();
+	for i in 0..subset.len() {
+		if let Some(v) = subset[i] {
+			poly_evals_with_zero.push(v * zero_eval[i]);
+		} else {
+			poly_evals_with_zero.push(BlsScalar::zero());
+		}
+	}
+	let mut poly_with_zero = eval_domain.ifft(&poly_evals_with_zero[..]);
+	shift_poly(&mut poly_with_zero[..]);
+	shift_poly(&mut zero_poly[..]);
+	let mut eval_shifted_poly_with_zero = eval_domain.fft(&poly_with_zero[..]);
+	let eval_shifted_zero_poly = eval_domain.fft(&zero_poly[..]);
+	for i in 0..eval_shifted_poly_with_zero.len() {
+		eval_shifted_poly_with_zero[i] *= eval_shifted_zero_poly[i].invert().unwrap();
+	}
+
+	let mut shifted_reconstructed_poly = eval_domain.ifft(&eval_shifted_poly_with_zero[..]);
+	unshift_poly(&mut shifted_reconstructed_poly[..]);
+
+	let reconstructed_data = eval_domain.fft(&shifted_reconstructed_poly[..]);
+	Ok(reconstructed_data)
+}
+
+fn expand_root_of_unity(eval_domain: EvaluationDomain) -> Vec<BlsScalar> {
+	let root_of_unity = eval_domain.group_gen;
+	let mut roots: Vec<BlsScalar> = Vec::new();
+	roots.push(BlsScalar::one());
+	roots.push(root_of_unity);
+	let mut i = 1;
+	while roots[i] != BlsScalar::one() {
+		roots.push(roots[i] * root_of_unity);
+		i += 1;
+	}
+	return roots;
+}
+
+fn zero_poly_fn(
+	eval_domain: EvaluationDomain,
+	missing_indices: &[u64],
+	length: u64,
+) -> (Vec<BlsScalar>, Vec<BlsScalar>) {
+	let expanded_r_o_u = expand_root_of_unity(eval_domain);
+	let domain_stride = eval_domain.size() as u64 / length;
+	let mut zero_poly: Vec<BlsScalar> = Vec::with_capacity(length as usize);
+	let mut sub: BlsScalar;
+	for i in 0..missing_indices.len() {
+		let v = missing_indices[i as usize];
+		sub = BlsScalar::zero() - expanded_r_o_u[(v * domain_stride) as usize];
+		zero_poly.push(sub);
+		if i > 0 {
+			zero_poly[i] = zero_poly[i] + zero_poly[i - 1];
+			for j in (1..i).rev() {
+				zero_poly[j] = zero_poly[j] * sub;
+				zero_poly[j] = zero_poly[j] + zero_poly[j - 1];
+			}
+			zero_poly[0] = zero_poly[0] * sub
+		}
+	}
+	zero_poly.push(BlsScalar::one());
+	for _ in zero_poly.len()..zero_poly.capacity() {
+		zero_poly.push(BlsScalar::zero());
+	}
+	let zero_eval = eval_domain.fft(&zero_poly[..]);
+	(zero_poly, zero_eval)
+}
+
+// in-place shifting
+fn shift_poly(poly: &mut [BlsScalar]) {
+	// primitive root of unity
+	let shift_factor = BlsScalar::from(5);
+	let mut factor_power = BlsScalar::one();
+	// hoping it won't panic, though it should be handled properly
+	//
+	// this is actually 1/ shift_factor --- multiplicative inverse
+	let inv_factor = shift_factor.invert().unwrap();
+
+	for i in 0..poly.len() {
+		poly[i] *= factor_power;
+		factor_power *= inv_factor;
+	}
+}
+
+// in-place unshifting
+fn unshift_poly(poly: &mut [BlsScalar]) {
+	// primitive root of unity
+	let shift_factor = BlsScalar::from(5);
+	let mut factor_power = BlsScalar::one();
+
+	for i in 0..poly.len() {
+		poly[i] *= factor_power;
+		factor_power *= shift_factor;
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::time::{SystemTime, UNIX_EPOCH};
+
+	use dusk_bytes::Serializable;
+	use rand::{rngs::StdRng, Rng, SeedableRng};
+
+	use super::*;
+
+	#[test]
+	fn data_reconstruction_success() {
+		let domain_size = 1usize << 4;
+		let eval_domain = EvaluationDomain::new(domain_size * 2).unwrap();
+
+		// some dummy source data I care about
+		let mut src: Vec<BlsScalar> = Vec::with_capacity(domain_size * 2);
+		for i in 0..domain_size {
+			src.push(BlsScalar::from(1 << (i + 1)));
+		}
+		// fill extended portion of vector with zeros
+		for _ in domain_size..(2 * domain_size) {
+			src.push(BlsScalar::zero());
+		}
+
+		// erasure code it
+		let coded_src = eval_domain.fft(&src);
+		// choose random subset of it ( >= 50% )
+		let (coded_src_subset, _) = random_subset(&coded_src);
+		// reconstruct 100% erasure coded values from random coded subset
+		let coded_recovered = reconstruct_poly(eval_domain, coded_src_subset).unwrap();
+
+		for i in 0..(2 * domain_size) {
+			assert_eq!(coded_src[i], coded_recovered[i]);
+		}
+
+		let dst = eval_domain.ifft(&coded_recovered);
+
+		for i in 0..(2 * domain_size) {
+			assert_eq!(src[i].to_bytes(), dst[i].to_bytes());
+		}
+	}
+
+	#[test]
+	fn data_reconstruction_failure_0() {
+		let domain_size = 1usize << 4;
+		let eval_domain = EvaluationDomain::new(domain_size * 2).unwrap();
+
+		let mut src: Vec<BlsScalar> = Vec::with_capacity(domain_size * 2);
+		for i in 0..domain_size {
+			src.push(BlsScalar::from(1 << (i + 1)));
+		}
+		for _ in domain_size..(2 * domain_size) {
+			src.push(BlsScalar::zero());
+		}
+
+		let coded_src = eval_domain.fft(&src);
+		let (mut coded_src_subset, available) = random_subset(&coded_src);
+		// intentionally drop a few coded elements such that
+		// < 50% is available
+		drop_few(&mut coded_src_subset, available);
+		// attempt to reconstruct 100% coded data from <50 % coded data
+		// I've available
+		let coded_recovered = reconstruct_poly(eval_domain, coded_src_subset).unwrap();
+
+		let mut mismatch_count = 0;
+		for i in 0..(2 * domain_size) {
+			if coded_src[i] != coded_recovered[i] {
+				mismatch_count += 1;
+			}
+		}
+
+		assert!(mismatch_count > 0);
+	}
+
+	// Context behind following two test cases, where one failure condition
+	// along with one possible solution, is demonstrated
+	//
+	// Need for writing these test cases originates in a conversation
+	// with Prabal<https://github.com/prabal-banerjee> where we were discussing
+	// how to ensure input byte chunks to dusk-plonk's `BlsScalar::from_bytes()`
+	// is always lesser than prime field modulus ( 255 bits wide ), because
+	// we'll get data bytes from arbitrary sources which will be concatenated into
+	// single large byte array & finally (multiple) field elements to be produced by chunking contiguous bytes,
+	// splitting bytearray into smaller chunks, each of size 32 bytes.
+	//
+	// Now imagine we got a 32-bytes wide chunk with content like [0xff; 32] --- all 256 -bits are set
+	//
+	// When that's attempted to be converted into field element it should be wrapped
+	// around and original value will be lost
+	//
+	// We want to specify a way for `how a large byte string can be splitted into field elements
+	// such that no values are required to be wrapped around due to modular division i.e. all
+	// values must be lesser than 255-bit prime before they are attempted to be converted to BLS scalar ?`
+	//
+	// One natural way to think about solving this problem is grouping large byte array into 254-bits
+	// chunks, then we should not encounter that problem as value is always lesser than
+	// prime number which is 255 -bits. But that requires indexing within a byte i.e. not at byte boundary.
+	//
+	// **Solution** So we decided to chunk contiguous 31 bytes from large input byte array and
+	// append zero byte(s) to each chunk for making 32 -bytes wide before inputting
+	// 256 -bit integer to `BlsScalar::from_bytes( ... )` function
+	//
+	// Note, this means, for each field element of 256 -bits, we've 6 -bits free to use
+	// and at this moment that's just set to zeros !
+	// Other 2 -bits of MSB will always be 0 for avoiding modular division related issue.
+	//
+	// Is there a way to make use of 6 -bits of most significant byte, in every field element ?
+	//
+	// Test `data_reconstruction_failure_1` shows how chunking with 32 contiguous bytes
+	// results into error where data is lost due to modular division
+	//
+	// While `data_reconstruction_failure_2` shows how chunking 31 bytes together
+	// makes it work smoothly without any data loss encountered !
+	#[test]
+	#[should_panic]
+	fn data_reconstruction_failure_1() {
+		const GROUP_TOGETHER: usize = 32; // bytes
+
+		let input = [0xffu8; (32 << 4) + 1];
+
+		let domain_size = ((input.len() as f64) / GROUP_TOGETHER as f64).ceil() as usize;
+		let eval_domain = EvaluationDomain::new(domain_size * 2).unwrap();
+
+		let mut input_wide: Vec<[u8; 32]> = Vec::with_capacity(domain_size);
+
+		for chunk in input.chunks(GROUP_TOGETHER) {
+			let widened: [u8; 32] = {
+				let mut v = vec![];
+				v.extend_from_slice(&chunk.to_vec()[..]);
+				// pad last chunk with required -many zeros
+				for _ in 0..(GROUP_TOGETHER - chunk.len()) {
+					v.push(0u8);
+				} // v is 32 -bytes
+				v.try_into().unwrap()
+			};
+
+			input_wide.push(widened);
+		}
+
+		let mut src: Vec<BlsScalar> = Vec::with_capacity(domain_size * 2);
+		for i in 0..domain_size {
+			src.push(BlsScalar::from_bytes(&input_wide[i]).unwrap());
+		}
+		for _ in 0..domain_size {
+			src.push(BlsScalar::zero());
+		}
+
+		// erasure code it
+		let coded_src = eval_domain.fft(&src);
+		// choose random subset of it ( >= 50% )
+		let (coded_src_subset, _) = random_subset(&coded_src);
+		// reconstruct 100% erasure coded values from random coded subset
+		let coded_recovered = reconstruct_poly(eval_domain, coded_src_subset).unwrap();
+
+		for i in 0..(2 * domain_size) {
+			assert_eq!(coded_src[i], coded_recovered[i]);
+		}
+
+		let dst = eval_domain.ifft(&coded_recovered);
+
+		for i in 0..domain_size {
+			let chunk_0 = if (i + 1) * GROUP_TOGETHER >= input.len() {
+				&input[i * GROUP_TOGETHER..]
+			} else {
+				&input[i * GROUP_TOGETHER..(i + 1) * GROUP_TOGETHER]
+			};
+			let chunk_1 = &dst[i].to_bytes()[..chunk_0.len()];
+
+			assert_eq!(chunk_0, chunk_1, "{}", format!("at i = {}", i));
+		}
+		for i in domain_size..(2 * domain_size) {
+			assert_eq!(
+				[0u8; GROUP_TOGETHER],
+				dst[i].to_bytes(),
+				"{}",
+				format!("at i = {}", i)
+			);
+		}
+	}
+
+	#[test]
+	fn data_reconstruction_failure_2() {
+		const GROUP_TOGETHER: usize = 31; // bytes
+
+		let input = [0xffu8; 32 << 4];
+
+		let domain_size = ((input.len() as f64) / GROUP_TOGETHER as f64).ceil() as usize;
+		let eval_domain = EvaluationDomain::new(domain_size * 2).unwrap();
+
+		let mut input_wide: Vec<[u8; 32]> = Vec::with_capacity(domain_size);
+
+		for chunk in input.chunks(GROUP_TOGETHER) {
+			let widened: [u8; 32] = {
+				let mut v = vec![];
+				v.extend_from_slice(&chunk.to_vec()[..]);
+				// pad last chunk with required -many zeros
+				for _ in 0..(GROUP_TOGETHER - chunk.len()) {
+					v.push(0u8);
+				} // v is 31 -bytes
+				v.push(0u8); // v is now 32 -bytes
+				v.try_into().unwrap()
+			};
+
+			input_wide.push(widened);
+		}
+
+		let mut src: Vec<BlsScalar> = Vec::with_capacity(domain_size * 2);
+		for i in 0..domain_size {
+			src.push(BlsScalar::from_bytes(&input_wide[i]).unwrap());
+		}
+		for _ in 0..domain_size {
+			src.push(BlsScalar::zero());
+		}
+
+		// erasure code it
+		let coded_src = eval_domain.fft(&src);
+		// choose random subset of it ( >= 50% )
+		let (coded_src_subset, _) = random_subset(&coded_src);
+		// reconstruct 100% erasure coded values from random coded subset
+		let coded_recovered = reconstruct_poly(eval_domain, coded_src_subset).unwrap();
+
+		for i in 0..(2 * domain_size) {
+			assert_eq!(coded_src[i], coded_recovered[i]);
+		}
+
+		let dst = eval_domain.ifft(&coded_recovered);
+
+		for i in 0..domain_size {
+			let chunk_0 = if (i + 1) * GROUP_TOGETHER >= input.len() {
+				&input[i * GROUP_TOGETHER..]
+			} else {
+				&input[i * GROUP_TOGETHER..(i + 1) * GROUP_TOGETHER]
+			};
+			let chunk_1 = &dst[i].to_bytes()[..chunk_0.len()];
+
+			assert_eq!(chunk_0, chunk_1, "{}", format!("at i = {}", i));
+		}
+		for i in domain_size..(2 * domain_size) {
+			assert_eq!(
+				[0u8; GROUP_TOGETHER + 1],
+				dst[i].to_bytes(),
+				"{}",
+				format!("at i = {}", i)
+			);
+		}
+	}
+
+	fn drop_few(data: &mut [Option<BlsScalar>], mut available: usize) {
+		assert!(available <= data.len());
+
+		let mut idx = 0;
+		while available >= data.len() / 2 {
+			if let Some(_) = data[idx] {
+				data[idx] = None;
+				available -= 1;
+			}
+			idx += 1;
+		}
+	}
+
+	// select a random subset of coded data to be used for
+	// reconstruction purpose
+	//
+	// @note this is just a helper function for writing test case
+	fn random_subset(data: &[BlsScalar]) -> (Vec<Option<BlsScalar>>, usize) {
+		let mut rng = StdRng::seed_from_u64(
+			SystemTime::now()
+				.duration_since(UNIX_EPOCH)
+				.unwrap()
+				.as_secs(),
+		);
+		let mut subset: Vec<Option<BlsScalar>> = Vec::with_capacity(data.len());
+		let mut available = 0;
+		for i in 0..data.len() {
+			if rng.gen::<u8>() % 2 == 0 {
+				subset.push(Some(data[i]));
+				available += 1;
+			} else {
+				subset.push(None);
+			}
+		}
+
+		// already we've >=50% data available
+		// so just return & attempt to reconstruct back
+		if available >= data.len() / 2 {
+			(subset, available)
+		} else {
+			for i in 0..data.len() {
+				if let None = subset[i] {
+					// enough data added, >=50% needs
+					// to be present
+					if available >= data.len() / 2 {
+						break;
+					}
+
+					subset[i] = Some(data[i]);
+					available += 1;
+				}
+			}
+			(subset, available)
+		}
+	}
+}

--- a/kate/recovery/src/com.rs
+++ b/kate/recovery/src/com.rs
@@ -122,7 +122,7 @@ fn unshift_poly(poly: &mut [BlsScalar]) {
 
 #[cfg(test)]
 mod tests {
-	use std::time::{SystemTime, UNIX_EPOCH};
+	use std::{time::{SystemTime, UNIX_EPOCH}, convert::TryInto};
 
 	use dusk_bytes::Serializable;
 	use rand::{rngs::StdRng, Rng, SeedableRng};

--- a/kate/recovery/src/com.rs
+++ b/kate/recovery/src/com.rs
@@ -48,7 +48,9 @@ pub fn reconstruct_poly(
 	let mut shifted_reconstructed_poly = eval_domain.ifft(&eval_shifted_poly_with_zero[..]);
 	unshift_poly(&mut shifted_reconstructed_poly[..]);
 
-	let reconstructed_data = eval_domain.fft(&shifted_reconstructed_poly[..]);
+	let short_domain = EvaluationDomain::new(eval_domain.size()/2).unwrap();
+
+	let reconstructed_data = short_domain.fft(&shifted_reconstructed_poly[..]);
 	Ok(reconstructed_data)
 }
 

--- a/kate/recovery/src/lib.rs
+++ b/kate/recovery/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod com;

--- a/kate/src/com.rs
+++ b/kate/src/com.rs
@@ -673,7 +673,7 @@ mod tests {
 			.map(|col| {
 				col.into_iter()
 					.enumerate()
-					.filter(|(i, e)| i % 2 == 0)
+					.filter(|(i, _)| i % 2 == 0)
 					.map(|(_, e)| e)
 					.collect::<Vec<_>>()
 			})
@@ -721,7 +721,7 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 
 		let cols = coded.chunks_exact(extended_dims.rows).collect::<Vec<_>>();
 
-		let eval_domain = EvaluationDomain::new(extended_dims.rows).unwrap();
+		EvaluationDomain::new(extended_dims.rows).unwrap();
 		let res = cols
 			.iter()
 			.map(|e| {
@@ -739,16 +739,15 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 				let samples = chosen_idx
 					.into_iter()
 					.map(|i| {
-						let cell = Cell {
+						Cell {
 							row: i as u16,
 							proof: e[i].clone().to_bytes().to_vec(),
 							..Default::default()
-						};
-						cell
+						}
 					})
 					.collect::<Vec<_>>();
 
-				let reconstructed = reconstruct_column(extended_dims.rows, &samples[..]).unwrap();
+				let reconstructed = reconstruct_column(extended_dims.rows, samples.as_slice()).unwrap();
 				// dbg!(reconstructed.clone());
 				// assert_eq!(&reconstructed, e);
 				// reconstructed
@@ -760,7 +759,6 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 		// dbg!(res.clone());
 		// assert_eq!(res, cols);
 		assert!(res.len() % 2 == 0);
-		let newlen = res.len() / 2;
 		let scalars = truncate_flatten_matrix(res)
 			.iter()
 			.flat_map(|e| e.to_bytes())

--- a/kate/src/com.rs
+++ b/kate/src/com.rs
@@ -476,7 +476,7 @@ mod tests {
 
 	use da_primitives::asdr::AppExtrinsic;
 	use dusk_bytes::Serializable;
-	use dusk_plonk::bls12_381::BlsScalar;
+	use dusk_plonk::{bls12_381::BlsScalar, fft::EvaluationDomain};
 	use frame_support::assert_ok;
 	use test_case::test_case;
 

--- a/kate/src/com.rs
+++ b/kate/src/com.rs
@@ -669,19 +669,6 @@ mod tests {
 		}
 	}
 
-	fn truncate_flatten_matrix(cols: Vec<Vec<BlsScalar>>) -> Vec<BlsScalar> {
-		cols.to_vec()
-			.into_iter()
-			.map(|col| {
-				col.into_iter()
-					.enumerate()
-					.filter(|(i, _)| i % 2 == 0)
-					.map(|(_, e)| e)
-			})
-			.flatten()
-			.collect::<Vec<BlsScalar>>()
-	}
-
 	fn sample_cells_from_matrix(
 		matrix: Vec<BlsScalar>,
 		dimensions: &BlockDimensions,
@@ -718,7 +705,22 @@ mod tests {
 			.collect::<Vec<_>>()
 	}
 
-	fn reconstruct_matrix(
+	fn truncate_flatten_matrix(cols: Vec<Vec<BlsScalar>>) -> Vec<BlsScalar> {
+		cols.to_vec()
+			.into_iter()
+			.map(|col| {
+				col.into_iter()
+					.enumerate()
+					.filter(|(i, _)| i % 2 == 0)
+					.map(|(_, e)| e)
+			})
+			.flatten()
+			.collect::<Vec<BlsScalar>>()
+	}
+
+	// TODO: This code depends on structures which are not shared between kate and kate_recovery crates,
+	// which disables moving it into kate_recovery crate. This should be solved once we want to expose publicly this method.
+	fn reconstruct_app_extrinsics(
 		layout: Vec<(u32, u32)>,
 		columns: Vec<Vec<Cell>>,
 		dimensions: BlockDimensions,
@@ -762,7 +764,7 @@ mod tests {
 			let (layout, _, dimensions, matrix) = build_commitments(64, 16, 32, xts, &hash.as_slice()).unwrap();
 
 			let columns = sample_cells_from_matrix(matrix, &dimensions);
-			let reconstructed = reconstruct_matrix(layout, columns, dimensions);
+			let reconstructed = reconstruct_app_extrinsics(layout, columns, dimensions);
 
 			for (result, xt) in reconstructed.iter().zip(xts) {
 				prop_assert_eq!(result.app_id, xt.app_id);

--- a/kate/src/com.rs
+++ b/kate/src/com.rs
@@ -669,6 +669,15 @@ mod tests {
 		}
 	}
 
+	fn app_extrinsics_from_vec(vec: &Vec<(u32, Vec<u8>)>) -> Vec<AppExtrinsic> {
+		vec.iter()
+			.map(|a| AppExtrinsic {
+				app_id: a.0,
+				data: a.1.clone(),
+			})
+			.collect::<Vec<AppExtrinsic>>()
+	}
+
 	fn sample_cells_from_matrix(
 		matrix: Vec<BlsScalar>,
 		dimensions: &BlockDimensions,
@@ -729,9 +738,9 @@ mod tests {
 			.iter()
 			.map(|cells| reconstruct_column(dimensions.rows * 2, &cells).unwrap())
 			.collect::<Vec<_>>();
-		let scalars = truncate_flatten_matrix(reconstructed)
+		let scalars = reconstructed
 			.iter()
-			.flat_map(|e| e.to_bytes())
+			.flat_map(|e| e.iter().flat_map(|e| e.to_bytes()).collect::<Vec<_>>())
 			.collect::<Vec<_>>();
 
 		unflatten_padded_data(layout, scalars, dimensions.chunk_size).unwrap()
@@ -836,11 +845,12 @@ Let's see how this gets encoded and then reconstructed by sampling only some dat
 		// dbg!(res.clone());
 		// assert_eq!(res, cols);
 		assert!(res.len() % 2 == 0);
-		let bytes = truncate_flatten_matrix(res)
+		let scalars = res
 			.iter()
-			.flat_map(|e| e.to_bytes())
+			.flat_map(|e| e.iter().flat_map(|e| e.to_bytes()).collect::<Vec<_>>())
 			.collect::<Vec<_>>();
-		let res = unflatten_padded_data(layout, bytes, chunk_size).unwrap();
+
+		let res = unflatten_padded_data(layout, scalars, chunk_size).unwrap();
 
 		// let decoded = decode_scalars(&res.as_slice());
 		let s = String::from_utf8_lossy(res[0].data.as_slice());


### PR DESCRIPTION
This PR adds modified @itzmeanjan code for reconstruction, which reconstructs original extrinsic data from erasure coded matrix. Currently this is used in tests (to generate, encode, sample and reconstruct data), and its partially exposed to be used in light client. Next iteration will define concrete interface to be used on application clients.
