### PR TITLE
Add proof testing to reconstruction test.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,6 +2929,7 @@ dependencies = [
  "frame-support",
  "getrandom 0.2.4",
  "hex",
+ "kate-proof",
  "kate-recovery",
  "log",
  "num_cpus",

--- a/kate/Cargo.toml
+++ b/kate/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 da-primitives = { path = "../primitives", default-features = false }
-kate-recovery = { path = "recovery", default-features = true }
 
 # Others
 dusk-plonk = { version = "0.8.2", default-features = false, optional = true }
@@ -34,6 +33,8 @@ frame-support = { version = "4.0.0-dev", default-features = false }
 [dev-dependencies]
 test-case = "1.2.3"
 proptest = "1.0.0"
+kate-recovery = { path = "recovery", default-features = false }
+kate-proof = { path = "proof", default-features = false }
 
 [features]
 default = ["std"]

--- a/kate/proof/Cargo.toml
+++ b/kate/proof/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.41"
-dusk-plonk =  {git = "https://github.com/maticnetwork/plonk.git", tag = "v0.8.2-polygon-2"}
-dusk-bytes = { version = "0.1.5"}
+dusk-plonk = { git = "https://github.com/maticnetwork/plonk.git", tag = "v0.8.2-polygon-2" }
+dusk-bytes = { version = "0.1.5" }
 sp-core = { version = "4.0.0-dev" }
 hex = "0.4"
 rand = "0.8.4"
 rand_chacha = "0.3"
-merlin = {version = "3.0", default-features = false}
+merlin = {version = "3.0"}

--- a/kate/recovery/Cargo.toml
+++ b/kate/recovery/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Denis Ermolin <denis.ermolin@matic.network>"]
 edition = "2018"
 
 [dependencies]
-dusk-plonk =  {git = "https://github.com/maticnetwork/plonk.git", tag = "v0.8.2-polygon-2"}
-dusk-bytes = { version = "0.1.5"}
-getrandom = { version = "0.2", features = ["js"]}
+dusk-plonk = { git = "https://github.com/maticnetwork/plonk.git", tag = "v0.8.2-polygon-2" }
+dusk-bytes = { version = "0.1.5" }
+getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 rand = { version = "0.8.4" }


### PR DESCRIPTION
This PR adds proof generation and verification to test_build_and_reconstruct. Proof is generated and verified for 1% cells of 20 randomly generated inputs as temporary performance constraint. This should fine starting point to cover most cases in complete encode/reconstruct/generate and verify proof flow. Some of the cases are not covered, like when proof is incorrect and that should be added as separate test later.