### PR TITLE
Fix crates versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "da-runtime"
-version = "1.0.0"
+version = "4.0.0"
 dependencies = [
  "da-control",
  "da-primitives",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "data-avail"
-version = "3.0.0"
+version = "1.0.0"
 dependencies = [
  "da-control",
  "da-primitives",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-avail"
-version = "3.0.0"
+version = "1.0.0"
 description = "Polygon Data Avilability Node."
 authors = ["Anonymous"]
 homepage = "https://polygon.technology/"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "da-runtime"
-version = "1.0.0"
+version = "4.0.0"
 authors = ["Anonymous"]
 description = "Polygon Data Avilability Runtime"
 edition = "2018"


### PR DESCRIPTION
# Description
Corrections on the version of some crates.

- The binary node version is now `1.0.0`. 
- The version of the runtime crate is aligned to `RuntimeVersion` defined in `runtime/src/lib.rs`