### PR TITLE
Replace layout with app index in public functions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3015,6 +3015,7 @@ dependencies = [
  "parity-scale-codec 3.1.2",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "serde",
  "thiserror",
 ]
 

--- a/kate/recovery/Cargo.toml
+++ b/kate/recovery/Cargo.toml
@@ -10,6 +10,7 @@ dusk-plonk = { git = "https://github.com/maticnetwork/plonk.git", tag = "v0.8.2-
 dusk-bytes = { version = "0.1.5" }
 getrandom = { version = "0.2", features = ["js"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 rand = "0.8.4" 


### PR DESCRIPTION
This PR exposes app index (data offsets) in public functions of recovery crate, which enables removal of layout abstraction from avail-light repository.

Notes:
- Naming: struct is named `AppDataIndex` to minimize code changes on avail-light side (since same structure was used there). Struct contains `size` and `index` fields. Since index is already included in struct name, maybe better alternative would be `offsets`. I think its ok to leave it as it is atm since rename is not hard.
- Modules: everything is put under the recovery/com module. We should consider if we want to have separate mod for structs (e.g. `types)`, or some alternative. Also, this will be changed once we agree how to share schemas and code between projects.
- `ExtendedMatrixDimensions` and `AppDataIndex` are passed together in all cases, this could imply they should be coupled in some other structure (e.g. `BlockMetadata`) in the future.
- `data_ranges` function is public since it is used in `kate` mod tests. This implies that `kate` and `recovery` mods are not properly separated, and it should be addressed later. Same is for `TryFrom` trait implementation.
- `TryFrom` implementation is a copy of `DataLookup` struct implementation from `primitives/asdr` mod, which could not be reused due to substrate dependency. This should also be addressed in the future.