### PR TITLE
Remove sp-core dependency from kate/proof.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2998,11 +2998,9 @@ dependencies = [
  "anyhow",
  "dusk-bytes",
  "dusk-plonk",
- "hex",
  "merlin 3.0.0",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "sp-core",
 ]
 
 [[package]]

--- a/kate/proof/Cargo.toml
+++ b/kate/proof/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 anyhow = "1.0.41"
 dusk-plonk = { git = "https://github.com/maticnetwork/plonk.git", tag = "v0.8.2-polygon-2" }
 dusk-bytes = { version = "0.1.5" }
-sp-core = { version = "4.0.0-dev" }
-hex = "0.4"
 rand = "0.8.4"
 rand_chacha = "0.3"
 merlin = {version = "3.0"}

--- a/kate/proof/src/lib.rs
+++ b/kate/proof/src/lib.rs
@@ -22,8 +22,7 @@ mod testnet {
 
 pub struct ProofVerification {
 	pub status: Result<(), dusk_plonk::error::Error>,
-	pub public_params_hash: String,
-	pub public_params_len: usize,
+	pub public_params: Vec<u8>,
 }
 
 // code for light client to verify incoming kate proofs
@@ -83,7 +82,6 @@ pub fn kc_verify_proof(
 
 	Ok(ProofVerification {
 		status,
-		public_params_hash: hex::encode(sp_core::blake2_128(&raw_pp)),
-		public_params_len: hex::encode(raw_pp).len(),
+		public_params: raw_pp,
 	})
 }


### PR DESCRIPTION
This PR removes sp-core dependency from kate/proof to decouple avail-light from sp-core version defined in avail project.