### PR TITLE
Add maximum block size feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,11 @@ For development purposes, its possible to use sudo calls with unchecked weight t
 ### Verify upgrade
 
 To check if runtime is upgraded, query `system/version:SpVersionRuntimeVersion` constant. This should return latest version values.
+
+## Testing
+
+### Generating blocks of maximum size
+
+Some load testing cases requires blocks of maximum size. To compile node which will always pad block with random data up to maximum block size, compile node with:
+
+	$> cargo build -p data-avail --features "kate/maximum-block-size"

--- a/kate/Cargo.toml
+++ b/kate/Cargo.toml
@@ -64,3 +64,5 @@ std = [
 	"da-primitives/std",
 ]
 extended-columns = []
+maximum-block-size = []
+

--- a/kate/src/com.rs
+++ b/kate/src/com.rs
@@ -25,8 +25,8 @@ use static_assertions::const_assert_eq;
 use crate::testnet;
 use crate::{
 	config::{
-		DATA_CHUNK_SIZE, EXTENSION_FACTOR, MAX_BLOCK_COLUMNS, MAX_PROOFS_REQUEST,
-		MINIMUM_BLOCK_SIZE, PROOF_SIZE, PROVER_KEY_SIZE, SCALAR_SIZE,
+		DATA_CHUNK_SIZE, EXTENSION_FACTOR, MAXIMUM_BLOCK_SIZE, MAX_BLOCK_COLUMNS,
+		MAX_PROOFS_REQUEST, MINIMUM_BLOCK_SIZE, PROOF_SIZE, PROVER_KEY_SIZE, SCALAR_SIZE,
 	},
 	padded_len_of_pad_iec_9797_1, BlockDimensions, Seed, LOG_TARGET,
 };
@@ -144,7 +144,7 @@ pub fn get_block_dimensions(
 		Error::BlockTooBig
 	);
 
-	if block_size == max_block_dimensions.size() {
+	if block_size == max_block_dimensions.size() || MAXIMUM_BLOCK_SIZE {
 		return Ok(max_block_dimensions);
 	}
 

--- a/kate/src/lib.rs
+++ b/kate/src/lib.rs
@@ -27,6 +27,7 @@ pub mod config {
 	} else {
 		256
 	};
+	pub const MAXIMUM_BLOCK_SIZE: bool = cfg!(feature = "maximum-block-size");
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
Idea of this PR is to support load testing of nodes and light clients. Compiling node with `maximum-block-size` feature will configure node to produce blocks of maximum size, which will be useful in testing of DHT performance of light clients.