### PR TITLE
[DVT-139] avail rust releaser ci integration

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -2,7 +2,7 @@ name: Polygon Avail Releaser
 on: push
 
 jobs:
-  release_awx:
+  release_centos7_amd64:
     runs-on: ubuntu-latest
     container:
       image: amd64/centos:centos7
@@ -28,3 +28,18 @@ jobs:
             ls -a
             yum install awscli -y
             aws s3 cp data-avail s3://avail-binaries/data-avail-git
+  release_darwin:
+    runs-on: macos-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+         - uses: actions/checkout@v2
+         - name: install cargo deps and build avail
+           run: |
+            cat /etc/os-release
+
+
+# add docker buildx
+
+# add binary builds for all other arch

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: amd64/centos:centos7
-     env:
+    env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -19,7 +19,6 @@ jobs:
             yum install llvm-toolset-7 -y
             yum install gcc-c++ -y
             scl enable llvm-toolset-7 bash
-            clang --version
             curl https://sh.rustup.rs -sSf | sh -s -- -y
             source "$HOME/.cargo/env"
             cargo build --release -p data-avail

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -24,23 +24,39 @@ jobs:
             curl https://sh.rustup.rs -sSf | sh -s -- -y
             source "$HOME/.cargo/env"
             cargo build --release -p data-avail
-            cd target/release
-            ls -a
-            yum install awscli -y
-            aws s3 cp data-avail s3://avail-binaries/data-avail-git
-  release_darwin:
-    runs-on: macos-latest
+
+  release_linux_amd64:
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/alpine:3.13
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
          - uses: actions/checkout@v2
-         - name: check os version
-           shell: bash
+         - name: install cargo deps and build avail
            run: |
-             uname -m
+            apt install curl -y
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            source "$HOME/.cargo/env"
+            cargo build --release -p data-avail
 
+  release_linux_arm64:
+    runs-on: ubuntu-latest
+    container:
+      image: arm64v8/alpine:3.13
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+         - uses: actions/checkout@v2
+         - name: install cargo deps and build avail
+           run: |
+            apt install curl -y
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            source "$HOME/.cargo/env"
+            cargo build --release -p data-avail
 
 # add docker buildx
 
-# add binary builds for all other arch
+# add binary builds for linux

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -2,26 +2,26 @@ name: Polygon Avail Releaser
 on: push
 
 jobs:
-  release_centos7_amd64:
-    runs-on: ubuntu-latest
-    container:
-      image: amd64/centos:centos7
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    steps:
-         - uses: actions/checkout@v2
-         - name: install cargo deps and build avail
-           run: |
-            yum install centos-release-scl -y
-            yum install llvm-toolset-7 -y
-            yum install gcc-c++ -y
-            scl enable llvm-toolset-7 bash
-            export PATH="/opt/rh/llvm-toolset-7/root/usr/bin:$PATH"
-            export LIBCLANG_PATH="/opt/rh/llvm-toolset-7/root/usr/lib64/"
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-            source "$HOME/.cargo/env"
-            cargo build --release -p data-avail
+  # release_centos7_amd64:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: amd64/centos:centos7
+  #   env:
+  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #   steps:
+  #        - uses: actions/checkout@v2
+  #        - name: install cargo deps and build avail
+  #          run: |
+  #           yum install centos-release-scl -y
+  #           yum install llvm-toolset-7 -y
+  #           yum install gcc-c++ -y
+  #           scl enable llvm-toolset-7 bash
+  #           export PATH="/opt/rh/llvm-toolset-7/root/usr/bin:$PATH"
+  #           export LIBCLANG_PATH="/opt/rh/llvm-toolset-7/root/usr/lib64/"
+  #           curl https://sh.rustup.rs -sSf | sh -s -- -y
+  #           source "$HOME/.cargo/env"
+  #           cargo build --release -p data-avail
 
   release_linux_amd64:
     runs-on: ubuntu-latest
@@ -34,7 +34,7 @@ jobs:
          - uses: actions/checkout@v2
          - name: install cargo deps and build avail
            run: |
-            apt-get install curl -y
+            sudo apt-get install curl -y
             curl https://sh.rustup.rs -sSf | sh -s -- -y
             source "$HOME/.cargo/env"
             cargo build --release -p data-avail
@@ -50,7 +50,7 @@ jobs:
          - uses: actions/checkout@v2
          - name: install cargo deps and build avail
            run: |
-            apt-get install curl -y
+            sudo apt-get install curl -y
             curl https://sh.rustup.rs -sSf | sh -s -- -y
             source "$HOME/.cargo/env"
             cargo build --release -p data-avail

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -39,22 +39,38 @@ jobs:
             source "$HOME/.cargo/env"
             cargo build --release -p data-avail
 
-  release_linux_arm64:
+  docker_releases:
     runs-on: ubuntu-latest
-    container:
-      image: arm64v8/ubuntu:jammy
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
-         - uses: actions/checkout@v2
-         - name: install cargo deps and build avail
-           run: |
-            sudo apt-get install curl -y
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-            source "$HOME/.cargo/env"
-            cargo build --release -p data-avail
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Prepare
+        id: prepare
+        run: |
+            TAG=${GITHUB_REF#refs/tags/}
+            echo ::set-output name=tag_name::${TAG}
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.prepare.outputs.tag_name }}
 
 # add docker buildx
 
-# add binary builds for linux
+# add binary builds for linux (arm64 need self-hosted runner...)

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,14 +1,8 @@
 name: Polygon Avail Releaser
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: push
 
 jobs:
-  release-awx:
+  release_awx:
     runs-on: ubuntu-latest
     container:
       image: amd64/centos:centos7

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,0 +1,29 @@
+name: Polygon Avail Releaser
+on: push
+
+jobs:
+  release-awx:
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/centos:centos7
+     env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+         - uses: actions/checkout@v2
+         - name: install cargo deps and build avail
+           run: |
+            cat /etc/os-release
+            yum install git -y
+            yum install centos-release-scl -y
+            yum install llvm-toolset-7 -y
+            yum install gcc-c++ -y
+            scl enable llvm-toolset-7 bash
+            clang --version
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            source "$HOME/.cargo/env"
+            cargo build --release -p data-avail
+            cd target/release
+            ls
+            yum install awscli -y
+            aws s3 cp data-avail s3://avail-binaries/data-avail-git

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -13,8 +13,6 @@ jobs:
          - uses: actions/checkout@v2
          - name: install cargo deps and build avail
            run: |
-            cat /etc/os-release
-            yum install git -y
             yum install centos-release-scl -y
             yum install llvm-toolset-7 -y
             yum install gcc-c++ -y
@@ -28,7 +26,7 @@ jobs:
   release_linux_amd64:
     runs-on: ubuntu-latest
     container:
-      image: amd64/alpine:3.13
+      image: amd64/ubuntu:jammy
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -36,7 +34,7 @@ jobs:
          - uses: actions/checkout@v2
          - name: install cargo deps and build avail
            run: |
-            apk add curl
+            apt-get install curl -y
             curl https://sh.rustup.rs -sSf | sh -s -- -y
             source "$HOME/.cargo/env"
             cargo build --release -p data-avail
@@ -44,7 +42,7 @@ jobs:
   release_linux_arm64:
     runs-on: ubuntu-latest
     container:
-      image: arm64v8/alpine:3.13
+      image: arm64v8/ubuntu:jammy
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -52,7 +50,7 @@ jobs:
          - uses: actions/checkout@v2
          - name: install cargo deps and build avail
            run: |
-            apk add curl
+            apt-get install curl -y
             curl https://sh.rustup.rs -sSf | sh -s -- -y
             source "$HOME/.cargo/env"
             cargo build --release -p data-avail

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -24,6 +24,6 @@ jobs:
             source "$HOME/.cargo/env"
             cargo build --release -p data-avail
             cd target/release
-            ls
+            ls -a
             yum install awscli -y
             aws s3 cp data-avail s3://avail-binaries/data-avail-git

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -36,7 +36,7 @@ jobs:
          - uses: actions/checkout@v2
          - name: install cargo deps and build avail
            run: |
-            apt-get install curl -y
+            apk add curl
             curl https://sh.rustup.rs -sSf | sh -s -- -y
             source "$HOME/.cargo/env"
             cargo build --release -p data-avail
@@ -52,7 +52,7 @@ jobs:
          - uses: actions/checkout@v2
          - name: install cargo deps and build avail
            run: |
-            apt-get install curl -y
+            apk add curl
             curl https://sh.rustup.rs -sSf | sh -s -- -y
             source "$HOME/.cargo/env"
             cargo build --release -p data-avail

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -19,10 +19,4 @@ jobs:
             yum install llvm-toolset-7 -y
             yum install gcc-c++ -y
             scl enable llvm-toolset-7 bash
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-            source "$HOME/.cargo/env"
-            cargo build --release -p data-avail
-            cd target/release
-            ls -a
-            yum install awscli -y
-            aws s3 cp data-avail s3://avail-binaries/data-avail-git
+            yum whatprovides *libclang.so

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,5 +1,11 @@
 name: Polygon Avail Releaser
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   release-awx:

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -35,9 +35,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
          - uses: actions/checkout@v2
-         - name: install cargo deps and build avail
+         - name: check os version
+           shell: bash
            run: |
-            uname -m
+             uname -m
 
 
 # add docker buildx

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -36,7 +36,7 @@ jobs:
          - uses: actions/checkout@v2
          - name: install cargo deps and build avail
            run: |
-            apt install curl -y
+            apt-get install curl -y
             curl https://sh.rustup.rs -sSf | sh -s -- -y
             source "$HOME/.cargo/env"
             cargo build --release -p data-avail
@@ -52,7 +52,7 @@ jobs:
          - uses: actions/checkout@v2
          - name: install cargo deps and build avail
            run: |
-            apt install curl -y
+            apt-get install curl -y
             curl https://sh.rustup.rs -sSf | sh -s -- -y
             source "$HOME/.cargo/env"
             cargo build --release -p data-avail

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,76 +1,108 @@
-name: Polygon Avail Releaser
-on: push
+name: Releaser
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+      # to be used by fork patch-releases ^^
+      - 'v*.*.*-*'
 
 jobs:
-  # release_centos7_amd64:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: amd64/centos:centos7
-  #   env:
-  #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #   steps:
-  #        - uses: actions/checkout@v2
-  #        - name: install cargo deps and build avail
-  #          run: |
-  #           yum install centos-release-scl -y
-  #           yum install llvm-toolset-7 -y
-  #           yum install gcc-c++ -y
-  #           scl enable llvm-toolset-7 bash
-  #           export PATH="/opt/rh/llvm-toolset-7/root/usr/bin:$PATH"
-  #           export LIBCLANG_PATH="/opt/rh/llvm-toolset-7/root/usr/lib64/"
-  #           curl https://sh.rustup.rs -sSf | sh -s -- -y
-  #           source "$HOME/.cargo/env"
-  #           cargo build --release -p data-avail
 
-  release_linux_amd64:
+  # awx compatible binary with correct version of gcc and clang
+  binary_centos7_amd64:
     runs-on: ubuntu-latest
     container:
-      image: amd64/ubuntu:jammy
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      image: amd64/centos:centos7
     steps:
          - uses: actions/checkout@v2
          - name: install cargo deps and build avail
            run: |
-            sudo apt-get install curl -y
+            yum install centos-release-scl -y
+            yum install llvm-toolset-7 -y
+            yum install gcc-c++ -y
+            scl enable llvm-toolset-7 bash
+            export PATH="/opt/rh/llvm-toolset-7/root/usr/bin:$PATH"
+            export LIBCLANG_PATH="/opt/rh/llvm-toolset-7/root/usr/lib64/"
             curl https://sh.rustup.rs -sSf | sh -s -- -y
             source "$HOME/.cargo/env"
             cargo build --release -p data-avail
+            mv target/release/data-avail target/release/data-avail-centos7-amd64
+         - uses: actions/upload-artifact@v2
+           with:
+             name: data-avail-centos7-amd64-binary
+             path: target/release/data-avail-centos7-amd64
 
-  docker_releases:
+  binary_linux_amd64:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+         - uses: actions/checkout@v2
+         - name: install cargo deps and build avail
+           shell: bash
+           run: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            source "$HOME/.cargo/env"
+            cargo build --release -p data-avail
+            mv target/release/data-avail target/release/data-avail-linux-amd64
+         - uses: actions/upload-artifact@v2
+           with:
+             name: data-avail-linux-amd64-binary
+             path: target/release/data-avail-linux-amd64
+
+  # compile all binaries from previous jobs into single release
+  binary_publish:
+    needs: [binary_centos7_amd64, binary_linux_amd64]
+    runs-on: ubuntu-latest
+    steps:
+         - uses: actions/download-artifact@v2
+           with:
+             name: data-avail-centos7-amd64-binary
+         - uses: actions/download-artifact@v2
+           with:
+             name: data-avail-linux-amd64-binary
+         - name: Prepare
+           id: prepare
+           run: |
+               TAG=${GITHUB_REF#refs/tags/}
+               echo ::set-output name=tag_name::${TAG}
+         - name: publish binaries
+           uses: svenstaro/upload-release-action@v2
+           with:
+             repo_token: ${{ secrets.PAT_TOKEN }}
+             file: /home/runner/work/avail/avail/data-avail*
+             release_name: ${{ steps.prepare.outputs.tag_name }}
+             tag: ${{ steps.prepare.outputs.tag_name }}
+             overwrite: true
+             file_glob: true
+
+  # build avail image and publish to dockerhub
+  docker_linux_amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
         uses: actions/checkout@v2
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Prepare
+      - name: Prepare
         id: prepare
         run: |
             TAG=${GITHUB_REF#refs/tags/}
             echo ::set-output name=tag_name::${TAG}
-      -
-        name: Login to DockerHub
+      - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push images
         uses: docker/build-push-action@v3
         with:
+          builder: ${{ steps.buildx.outputs.name }}
           context: .
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.prepare.outputs.tag_name }}
-
-# add docker buildx
-
-# add binary builds for linux (arm64 need self-hosted runner...)
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: 0xpolygon/avail:${{ steps.prepare.outputs.tag_name }}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -19,4 +19,12 @@ jobs:
             yum install llvm-toolset-7 -y
             yum install gcc-c++ -y
             scl enable llvm-toolset-7 bash
-            yum whatprovides *libclang.so
+            export PATH="/opt/rh/llvm-toolset-7/root/usr/bin:$PATH"
+            export LIBCLANG_PATH="/opt/rh/llvm-toolset-7/root/usr/lib64/"
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            source "$HOME/.cargo/env"
+            cargo build --release -p data-avail
+            cd target/release
+            ls -a
+            yum install awscli -y
+            aws s3 cp data-avail s3://avail-binaries/data-avail-git

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -37,7 +37,7 @@ jobs:
          - uses: actions/checkout@v2
          - name: install cargo deps and build avail
            run: |
-            cat /etc/os-release
+            uname -m
 
 
 # add docker buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Phase 0: Builder
+# =========================
+FROM paritytech/ci-linux:production as builder
+
+RUN apt-get update && \
+	apt-get install -y git openssh-client && \
+	rm -rf /var/lib/apt/lists && \
+  mkdir -p /avail
+
+COPY . /avail/
+
+RUN \
+	mkdir -p /da/bin && \
+	mkdir -p /da/genesis && \
+	# Build DA \
+	cp -r /avail/misc/genesis /da && \
+	cd /avail && \
+	cargo build --release -p data-avail && \
+	# Install binaries \
+	mv target/release/data-avail /da/bin
+
+
+# Phase 1: Binary deploy
+# =========================
+FROM debian:buster-slim
+
+RUN apt-get update && \
+	apt-get install -y curl && \
+	rm -rf /var/lib/apt/lists
+
+COPY --from=builder /da/ /da
+COPY entrypoint.sh /
+WORKDIR /da
+
+ENV \
+	DA_CHAIN="/da/genesis/testnet.chain.spec.raw.json" \
+	DA_NAME="AvailNode" \
+	DA_MAX_IN_PEERS=50 \
+	DA_MAX_OUT_PEERS=50 \
+	DA_P2P_PORT="30333"
+
+VOLUME ["/tmp", "/da/state", "/da/keystore"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+cat /entrypoint.sh;
+
+trap cleanup 1 2 3 6
+
+cleanup()
+{
+  echo "Done cleanup ... quitting."
+  exit 1
+}
+
+/da/bin/data-avail \
+	--validator \
+	--base-path /da/state \
+	--keystore-path /da/keystore \
+	--execution=NativeElseWasm \
+	--offchain-worker=Always \
+	--enable-offchain-indexing=true \
+	--name $DA_NAME \
+	--chain $DA_CHAIN \
+	--port $DA_P2P_PORT \
+	--bootnodes=/ip4/52.47.205.129/tcp/30333/p2p/12D3KooW9tVuCzq3eknsevL5uyqQ3LpVcuqtkTqropjNccbhsWBz \
+	--bootnodes=/ip4/15.237.127.118/tcp/30333/p2p/12D3KooWQtxig5HukFDwQzshGWgQEZAqGqdCN7AQBW7cQRJWCyxL \
+	--bootnodes=/ip4/52.47.205.129/tcp/30333/p2p/12D3KooW9tVuCzq3eknsevL5uyqQ3LpVcuqtkTqropjNccbhsWBz \
+	$@


### PR DESCRIPTION
**linear ticket:** https://linear.app/matic/issue/DVT-139/setup-avail-ci-rust-releaser

**purpose:**
automate avail releases (binaries + docker) with new github actions workflow

this workflow yields the following:
- linux/amd64, centos7/amd64 (for awx compatibility) binaries published directly to avail github releases
- linux/amd64 docker image, published directly to 0xpolygon dockerhub
- all builds run in parallel by leveraging separate github actions jobs (total release time ~40min for all jobs)

**smoke tests:**
to trigger the releaser workflow, a developer simply needs to tag the appropriate commit sha and push as follows: 
`git tag v1.0.0-alpha 517c52e`
`git push origin dan/rust_releaser tag v1.0.0-alpha`

this flow was tested fully, with resulting artifacts now available here:
- dockerhub: https://hub.docker.com/layers/avail/0xpolygon/avail/v1.0.0-alpha/images/sha256-400c4fd55562be1afe7312f0f3e3910c9ae4cf1def6d9ae061cb906e73a3df23?context=explore
- github releases: https://github.com/maticnetwork/avail/releases/tag/v1.0.0-alpha
- successful actions workflow tree: https://github.com/maticnetwork/avail/actions/runs/2747889752

<img width="582" alt="image" src="https://user-images.githubusercontent.com/100106211/181301896-bcc7e88e-1406-42d9-8c1b-3e8cc8f5cd63.png">

