### PR TITLE
Exposes `Header::Number` as compact type

### DIFF
--- a/primitives/src/header.rs
+++ b/primitives/src/header.rs
@@ -76,6 +76,7 @@ pub struct Header<Number: HeaderNumberTrait, Hash: KateHashTrait> {
 	pub parent_hash: Hash::Output,
 	/// The block number.
 	#[cfg_attr(feature = "std", serde(with = "number_serde"))]
+	#[codec(compact)]
 	pub number: Number,
 	/// The state trie merkle root
 	pub state_root: Hash::Output,
@@ -145,13 +146,20 @@ where
 	Hash::Output: Decode,
 {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+		let parent_hash = Decode::decode(input)?;
+		let number = <<Number as HasCompact>::Type>::decode(input)?.into();
+		let state_root = Decode::decode(input)?;
+		let extrinsics_root = Decode::decode(input)?;
+		let digest = Decode::decode(input)?;
+		let app_data_lookup = Decode::decode(input)?;
+
 		Ok(Self {
-			parent_hash: Decode::decode(input)?,
-			number: <<Number as HasCompact>::Type>::decode(input)?.into(),
-			state_root: Decode::decode(input)?,
-			extrinsics_root: Decode::decode(input)?,
-			digest: Decode::decode(input)?,
-			app_data_lookup: Decode::decode(input)?,
+			parent_hash,
+			number,
+			state_root,
+			extrinsics_root,
+			digest,
+			app_data_lookup,
 		})
 	}
 }


### PR DESCRIPTION
It solves the decoding issue of the header between `subxt` & the node.

**NOTE**:
It requires a complete clean (`cargo clean`) on `avail-subxt` due to changes on `avail.dev.metadata.scale`.