### PR TITLE
Post nomad primitives PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3520,9 +3520,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "lazycell"
@@ -4305,7 +4302,8 @@ version = "0.1.0"
 dependencies = [
  "ethers-core",
  "frame-support",
- "lazy_static",
+ "hex-literal",
+ "nomad-core",
  "parity-scale-codec 2.3.1",
  "parity-util-mem",
  "primitive-types 0.10.1",

--- a/primitives/nomad/merkle/Cargo.toml
+++ b/primitives/nomad/merkle/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+nomad-core = { path = "../nomad-core", default-features = false }
+
 # Substrate
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
@@ -18,9 +20,9 @@ parity-util-mem = { version = "0.10.2", default-features = false, features = ["p
 tiny-keccak = { version = "2.0.2", default-features = false, features = ["keccak"] }
 
 primitive-types = { version = "0.10.1", default-features = false, features = ["scale-info", "codec"] }
-lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 thiserror-no-std = "2.0.2"
 static_assertions = "1.1.0"
+hex-literal = "0.3.4"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -37,6 +39,7 @@ features = ["derive"]
 default = ["std"]
 std = [
 	"serde",
+	"nomad-core/std",
 	"primitive-types/serde",
 	"codec/std",
 	"scale-info/std",

--- a/primitives/nomad/merkle/src/lib.rs
+++ b/primitives/nomad/merkle/src/lib.rs
@@ -31,20 +31,112 @@ pub type NomadLightMerkle = light::LightMerkle<TREE_DEPTH>;
 pub type NomadProof = proof::Proof<TREE_DEPTH>;
 
 pub use error::{TreeError, VerifyingError, VerifyingError::VerificationFailed};
+use hex_literal::hex;
 pub use light::*;
 pub use proof::*;
 pub use utils::*;
 
-lazy_static::lazy_static! {
-	/// A cache of the zero hashes for each layer of the tree.
-	pub static ref ZERO_HASHES: [H256; TREE_DEPTH + 1] = {
-		let mut hashes = [H256::zero(); TREE_DEPTH + 1];
-		for i in 0..TREE_DEPTH {
-			hashes[i + 1] = hash_concat(hashes[i], hashes[i]);
-		}
-		hashes
-	};
-}
+/// A cache of the zero hashes for each layer of the tree.
+/// See `zero_hashes_pre_build()` test to check how it is calculated.
+pub const ZERO_HASHES: [H256; TREE_DEPTH + 1] = [
+	H256::zero(),
+	H256(hex!(
+		"ad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5"
+	)),
+	H256(hex!(
+		"b4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30"
+	)),
+	H256(hex!(
+		"21ddb9a356815c3fac1026b6dec5df3124afbadb485c9ba5a3e3398a04b7ba85"
+	)),
+	H256(hex!(
+		"e58769b32a1beaf1ea27375a44095a0d1fb664ce2dd358e7fcbfb78c26a19344"
+	)),
+	H256(hex!(
+		"0eb01ebfc9ed27500cd4dfc979272d1f0913cc9f66540d7e8005811109e1cf2d"
+	)),
+	H256(hex!(
+		"887c22bd8750d34016ac3c66b5ff102dacdd73f6b014e710b51e8022af9a1968"
+	)),
+	H256(hex!(
+		"ffd70157e48063fc33c97a050f7f640233bf646cc98d9524c6b92bcf3ab56f83"
+	)),
+	H256(hex!(
+		"9867cc5f7f196b93bae1e27e6320742445d290f2263827498b54fec539f756af"
+	)),
+	H256(hex!(
+		"cefad4e508c098b9a7e1d8feb19955fb02ba9675585078710969d3440f5054e0"
+	)),
+	H256(hex!(
+		"f9dc3e7fe016e050eff260334f18a5d4fe391d82092319f5964f2e2eb7c1c3a5"
+	)),
+	H256(hex!(
+		"f8b13a49e282f609c317a833fb8d976d11517c571d1221a265d25af778ecf892"
+	)),
+	H256(hex!(
+		"3490c6ceeb450aecdc82e28293031d10c7d73bf85e57bf041a97360aa2c5d99c"
+	)),
+	H256(hex!(
+		"c1df82d9c4b87413eae2ef048f94b4d3554cea73d92b0f7af96e0271c691e2bb"
+	)),
+	H256(hex!(
+		"5c67add7c6caf302256adedf7ab114da0acfe870d449a3a489f781d659e8becc"
+	)),
+	H256(hex!(
+		"da7bce9f4e8618b6bd2f4132ce798cdc7a60e7e1460a7299e3c6342a579626d2"
+	)),
+	H256(hex!(
+		"2733e50f526ec2fa19a22b31e8ed50f23cd1fdf94c9154ed3a7609a2f1ff981f"
+	)),
+	H256(hex!(
+		"e1d3b5c807b281e4683cc6d6315cf95b9ade8641defcb32372f1c126e398ef7a"
+	)),
+	H256(hex!(
+		"5a2dce0a8a7f68bb74560f8f71837c2c2ebbcbf7fffb42ae1896f13f7c7479a0"
+	)),
+	H256(hex!(
+		"b46a28b6f55540f89444f63de0378e3d121be09e06cc9ded1c20e65876d36aa0"
+	)),
+	H256(hex!(
+		"c65e9645644786b620e2dd2ad648ddfcbf4a7e5b1a3a4ecfe7f64667a3f0b7e2"
+	)),
+	H256(hex!(
+		"f4418588ed35a2458cffeb39b93d26f18d2ab13bdce6aee58e7b99359ec2dfd9"
+	)),
+	H256(hex!(
+		"5a9c16dc00d6ef18b7933a6f8dc65ccb55667138776f7dea101070dc8796e377"
+	)),
+	H256(hex!(
+		"4df84f40ae0c8229d0d6069e5c8f39a7c299677a09d367fc7b05e3bc380ee652"
+	)),
+	H256(hex!(
+		"cdc72595f74c7b1043d0e1ffbab734648c838dfb0527d971b602bc216c9619ef"
+	)),
+	H256(hex!(
+		"0abf5ac974a1ed57f4050aa510dd9c74f508277b39d7973bb2dfccc5eeb0618d"
+	)),
+	H256(hex!(
+		"b8cd74046ff337f0a7bf2c8e03e10f642c1886798d71806ab1e888d9e5ee87d0"
+	)),
+	H256(hex!(
+		"838c5655cb21c6cb83313b5a631175dff4963772cce9108188b34ac87c81c41e"
+	)),
+	H256(hex!(
+		"662ee4dd2dd7b2bc707961b1e646c4047669dcb6584f0d8d770daf5d7e7deb2e"
+	)),
+	H256(hex!(
+		"388ab20e2573d171a88108e79d820e98f26c0b84aa8b2f4aa4968dbb818ea322"
+	)),
+	H256(hex!(
+		"93237c50ba75ee485f4c22adf2f741400bdf8d6a9cc7df7ecae576221665d735"
+	)),
+	H256(hex!(
+		"8448818bb4ae4562849e949e17ac16e0be16688e156b5cf15e098c627c0056a9"
+	)),
+	H256(hex!(
+		"27ae5ba08d7291c96c8cbddcc148bf48a6d68c7974b94356f53754ef6171d757"
+	)),
+];
 
 /// A merkle proof
 pub trait MerkleProof {
@@ -79,5 +171,25 @@ pub trait Merkle: core::fmt::Debug + Default {
 		ensure!(expected == actual, VerificationFailed { expected, actual });
 
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use nomad_core::keccak256_concat;
+	use sp_core::H256;
+
+	use super::{TREE_DEPTH, ZERO_HASHES};
+
+	/// Ensures that `ZERO_HASHES` pre-build image is valid.
+	#[test]
+	fn zero_hashes_pre_build() {
+		// Build image.
+		let mut hashes = [H256::zero(); TREE_DEPTH + 1];
+		for i in 0..TREE_DEPTH {
+			hashes[i + 1] = keccak256_concat!(hashes[i], hashes[i]);
+		}
+
+		assert_eq!(hashes, ZERO_HASHES);
 	}
 }

--- a/primitives/nomad/nomad-core/src/lib.rs
+++ b/primitives/nomad/nomad-core/src/lib.rs
@@ -1,5 +1,33 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+/// Variadic macro used by `keccak256_concat` internally.
+#[macro_export]
+macro_rules! keccak256_concat_update {
+	($hasher:ident, $e:expr) => {{
+		$hasher.update($e.as_ref());
+	}};
+
+	($hasher:ident, $e:expr, $($es:expr),+) => {{
+		$hasher.update($e.as_ref());
+		$crate::keccak256_concat_update!($hasher, $($es),+);
+	}};
+}
+
+/// Calculates the Kecck 256 of arguments with NO extra allocations to join inputs.
+#[macro_export]
+macro_rules! keccak256_concat{
+	($($arg:tt)*) => {{
+		{
+			use tiny_keccak::Hasher as _;
+			let mut output = [0u8; 32];
+			let mut hasher = tiny_keccak::Keccak::v256();
+			$crate::keccak256_concat_update!(hasher, $($arg)*);
+			hasher.finalize(&mut output);
+			sp_core::H256::from(output)
+		}
+	}}
+}
+
 extern crate alloc;
 
 mod update_v2;
@@ -21,3 +49,42 @@ pub use utils::*;
 
 #[cfg(feature = "std")]
 pub mod test_utils;
+
+#[cfg(test)]
+mod test {
+	use sp_core::H256;
+	use sp_runtime::traits::{Hash, Keccak256};
+
+	/// Tests `keccak256_concat` macro expansion with several arguments.
+	#[test]
+	fn it_keccak_256_contact() {
+		let a = b"123";
+		let b = b"456";
+		let c = b"789";
+		let abc = vec![a, b, c]
+			.into_iter()
+			.flatten()
+			.copied()
+			.collect::<Vec<_>>();
+
+		// Single
+		let output = keccak256_concat!(a);
+		let expected = Keccak256::hash(&a[..]).into();
+		assert_eq!(output, expected);
+
+		// Variadic
+		let output = keccak256_concat!(a, b, c);
+		let expected = Keccak256::hash(abc.as_slice()).into();
+		assert_eq!(output, expected);
+
+		// Test `as_ref()`.
+		let output = keccak256_concat!(H256::default(), a, b);
+		let concat = vec![H256::default().as_bytes(), a, b]
+			.into_iter()
+			.flatten()
+			.copied()
+			.collect::<Vec<_>>();
+		let expected = Keccak256::hash(concat.as_slice()).into();
+		assert_eq!(output, expected);
+	}
+}

--- a/primitives/nomad/nomad-core/src/update.rs
+++ b/primitives/nomad/nomad-core/src/update.rs
@@ -3,7 +3,6 @@ use frame_support::pallet_prelude::*;
 use serde::{Deserialize, Serialize};
 use signature::{hash_message, Signature, SignatureError};
 use sp_core::{H160, H256};
-use tiny_keccak::{Hasher, Keccak};
 
 use crate::utils::home_domain_hash;
 
@@ -22,13 +21,11 @@ pub struct Update {
 impl Update {
 	/// Get signing hash for update
 	pub fn signing_hash(&self) -> H256 {
-		let mut output = [0u8; 32];
-		let mut hasher = Keccak::v256();
-		hasher.update(home_domain_hash(self.home_domain).as_ref());
-		hasher.update(self.previous_root.as_ref());
-		hasher.update(self.new_root.as_ref());
-		hasher.finalize(&mut output);
-		output.into()
+		keccak256_concat!(
+			home_domain_hash(self.home_domain),
+			self.previous_root,
+			self.new_root
+		)
 	}
 
 	fn prepended_hash(&self) -> H256 { hash_message(self.signing_hash()) }

--- a/primitives/nomad/nomad-core/src/update_v2.rs
+++ b/primitives/nomad/nomad-core/src/update_v2.rs
@@ -5,7 +5,6 @@ use frame_support::pallet_prelude::*;
 use serde::{Deserialize, Serialize};
 use signature::{hash_message, Signature, SignatureError};
 use sp_core::{H160, H256};
-use tiny_keccak::{Hasher, Keccak};
 
 use crate::utils::home_domain_hash;
 
@@ -22,12 +21,7 @@ pub struct UpdateV2 {
 impl UpdateV2 {
 	/// Get signing hash for update
 	pub fn signing_hash(&self) -> H256 {
-		let mut output = [0u8; 32];
-		let mut hasher = Keccak::v256();
-		hasher.update(home_domain_hash(self.home_domain).as_ref());
-		hasher.update(self.root.as_ref());
-		hasher.finalize(&mut output);
-		output.into()
+		keccak256_concat!(home_domain_hash(self.home_domain), self.root)
 	}
 
 	fn prepended_hash(&self) -> H256 { hash_message(self.signing_hash()) }

--- a/primitives/nomad/nomad-core/src/utils.rs
+++ b/primitives/nomad/nomad-core/src/utils.rs
@@ -1,40 +1,15 @@
 use sp_core::H256;
-use tiny_keccak::{Hasher, Keccak};
 
-const NOMAD_PREFIX: &str = "NOMAD";
-const ETH_PREFIX: &str = "\x19Ethereum Signed Message:\n32";
+const NOMAD_PREFIX: &[u8] = b"NOMAD";
+const ETH_PREFIX: &[u8] = b"\x19Ethereum Signed Message:\n32";
 
 /// Computes hash of home domain concatenated with "NOMAD"
 pub fn home_domain_hash(home_domain: u32) -> H256 {
-	let mut output = [0u8; 32];
-	let mut hasher = Keccak::v256();
-	hasher.update(home_domain.to_be_bytes().as_ref());
-	hasher.update(NOMAD_PREFIX.as_bytes());
-	hasher.finalize(&mut output);
-	output.into()
-}
-
-/// Compute the Keccak-256 hash of input bytes.
-pub fn keccak256<S>(bytes: S) -> [u8; 32]
-where
-	S: AsRef<[u8]>,
-{
-	let mut output = [0u8; 32];
-	let mut hasher = Keccak::v256();
-	hasher.update(bytes.as_ref());
-	hasher.finalize(&mut output);
-	output
+	keccak256_concat!(home_domain.to_be_bytes(), NOMAD_PREFIX)
 }
 
 /// Hash a message according to EIP-191 with the ethereum signed message prefix.
-pub fn to_eth_signed_message_hash(hash: &H256) -> H256 {
-	let mut output = [0u8; 32];
-	let mut hasher = Keccak::v256();
-	hasher.update(ETH_PREFIX.as_bytes());
-	hasher.update(hash.as_bytes());
-	hasher.finalize(&mut output);
-	output.into()
-}
+pub fn to_eth_signed_message_hash(hash: &H256) -> H256 { keccak256_concat!(ETH_PREFIX, hash) }
 
 /// Destination and destination-specific nonce combined in single field (
 /// (destination << 32) & nonce)

--- a/primitives/nomad/nomad-core/src/utils.rs
+++ b/primitives/nomad/nomad-core/src/utils.rs
@@ -1,11 +1,11 @@
 use sp_core::H256;
 
-const NOMAD_PREFIX: &[u8] = b"NOMAD";
+const NOMAD_SUFFIX: &[u8] = b"NOMAD";
 const ETH_PREFIX: &[u8] = b"\x19Ethereum Signed Message:\n32";
 
 /// Computes hash of home domain concatenated with "NOMAD"
 pub fn home_domain_hash(home_domain: u32) -> H256 {
-	keccak256_concat!(home_domain.to_be_bytes(), NOMAD_PREFIX)
+	keccak256_concat!(home_domain.to_be_bytes(), NOMAD_SUFFIX)
 }
 
 /// Hash a message according to EIP-191 with the ethereum signed message prefix.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1376,7 +1376,7 @@ impl_runtime_apis! {
 
 #[cfg(test)]
 mod tests {
-	use codec::{Decode, Encode};
+	use codec::Decode;
 	use hex_literal::hex;
 	use sp_keyring::Sr25519Keyring::Bob;
 	use sp_runtime::MultiAddress;


### PR DESCRIPTION
This PR contains minor improvements after Nomad primitives inclusion:


- Use `keccak256_concat` macro to **avoid extra allocations**.
- Replace `lazy_static` by a **pre-build value**. An unit test was added to ensure both are the same value.
- `NomadMessage::to_vec` uses less memory.
- New UT for `NON_BODY_LENGTH` to ensure it is synchronized with `NomadMessage`.