### PR TITLE
Compressed Binary for CI and aarch64-unknown-linux-gnu Target

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -4,9 +4,7 @@ on:
     branches-ignore:
       - '**'
     tags:
-      - 'v*.*.*'
-      # to be used by fork patch-releases ^^
-      - 'v*.*.*-*'
+      - '*'
 
 jobs:
 
@@ -50,9 +48,32 @@ jobs:
              name: data-avail-linux-amd64-binary
              path: target/release/data-avail-linux-amd64
 
+  binary_linux_aarch64:
+    runs-on: ubuntu-latest
+    steps:
+         - uses: actions/checkout@v2
+         - name: install cargo deps and build avail
+           shell: bash
+           run: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            source "$HOME/.cargo/env"
+
+            rustup target add aarch64-unknown-linux-gnu
+            sudo apt-get update && sudo apt-get install -y musl-tools clang gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev libc6-dev-arm64-cross
+            env  BINDGEN_EXTRA_CLANG_ARGS='--sysroot /usr/aarch64-linux-gnu' CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc cargo build --release --target=aarch64-unknown-linux-gnu -p data-avail
+            mv target/aarch64-unknown-linux-gnu/release/data-avail target/aarch64-unknown-linux-gnu/release/data-avail-linux-aarch64
+            pushd target/aarch64-unknown-linux-gnu/release/
+            tar czf data-avail-linux-aarch64.tar.gz data-avail-linux-aarch64
+            popd
+         - uses: actions/upload-artifact@v2
+           with:
+             name: data-avail-linux-aarch64-tar
+             path: target/aarch64-unknown-linux-gnu/release/data-avail-linux-aarch64.tar.gz
+
+
   # compile all binaries from previous jobs into single release
   binary_publish:
-    needs: [binary_centos7_amd64, binary_linux_amd64]
+    needs: [binary_centos7_amd64, binary_linux_amd64, binary_linux_aarch64]
     runs-on: ubuntu-latest
     steps:
          - uses: actions/download-artifact@v2
@@ -61,6 +82,9 @@ jobs:
          - uses: actions/download-artifact@v2
            with:
              name: data-avail-linux-amd64-binary
+         - uses: actions/download-artifact@v2
+           with:
+             name: data-avail-linux-aarch64-tar
          - name: Prepare
            id: prepare
            run: |


### PR DESCRIPTION
Adding a compressed arm build. I don't want to break anything so just testing for now and we can compress the other artifacts later to avoid breaking other automations.