### PR TITLE
compress amd64 binary, remove centos7

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -8,30 +8,6 @@ on:
 
 jobs:
 
-  # awx compatible binary with correct version of gcc and clang
-  binary_centos7_amd64:
-    runs-on: ubuntu-latest
-    container:
-      image: amd64/centos:centos7
-    steps:
-         - uses: actions/checkout@v2
-         - name: install cargo deps and build avail
-           run: |
-            yum install centos-release-scl -y
-            yum install llvm-toolset-7 -y
-            yum install gcc-c++ -y
-            scl enable llvm-toolset-7 bash
-            export PATH="/opt/rh/llvm-toolset-7/root/usr/bin:$PATH"
-            export LIBCLANG_PATH="/opt/rh/llvm-toolset-7/root/usr/lib64/"
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-            source "$HOME/.cargo/env"
-            cargo build --release -p data-avail
-            mv target/release/data-avail target/release/data-avail-centos7-amd64
-         - uses: actions/upload-artifact@v2
-           with:
-             name: data-avail-centos7-amd64-binary
-             path: target/release/data-avail-centos7-amd64
-
   binary_linux_amd64:
     runs-on: ubuntu-latest
     steps:
@@ -47,6 +23,25 @@ jobs:
            with:
              name: data-avail-linux-amd64-binary
              path: target/release/data-avail-linux-amd64
+             
+  binary_linux_amd64_tar:
+    runs-on: ubuntu-latest
+    steps:
+         - uses: actions/checkout@v2
+         - name: install cargo deps and build avail
+           shell: bash
+           run: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            source "$HOME/.cargo/env"
+            cargo build --release -p data-avail
+            mv target/release/data-avail target/release/data-avail-linux-amd64
+            pushd target/release/
+            tar czf data-avail-linux-amd64.tar.gz data-avail-linux-amd64
+            popd
+         - uses: actions/upload-artifact@v2
+           with:
+             name: data-avail-linux-amd64-tar
+             path: target/release/data-avail-linux-amd64.tar.gz
 
   binary_linux_aarch64:
     runs-on: ubuntu-latest
@@ -73,15 +68,15 @@ jobs:
 
   # compile all binaries from previous jobs into single release
   binary_publish:
-    needs: [binary_centos7_amd64, binary_linux_amd64, binary_linux_aarch64]
+    needs: [binary_linux_amd64, binary_linux_amd64_tar, binary_linux_aarch64]
     runs-on: ubuntu-latest
     steps:
          - uses: actions/download-artifact@v2
            with:
-             name: data-avail-centos7-amd64-binary
+             name: data-avail-linux-amd64-binary
          - uses: actions/download-artifact@v2
            with:
-             name: data-avail-linux-amd64-binary
+             name: data-avail-linux-amd64-tar
          - uses: actions/download-artifact@v2
            with:
              name: data-avail-linux-aarch64-tar


### PR DESCRIPTION
**purpose:** 
compress amd64 binaries to match aarch64

**follow-up**
remove uncompressed amd64 binary once downstream ansible playbooks refactored to unarchive compressed version

**tests:**
smoke tests, successful github actions release run: https://github.com/maticnetwork/avail/actions/runs/3161341290