### PR TITLE
Header Forward Compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,8 +1443,9 @@ dependencies = [
 [[package]]
 name = "da-primitives"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#552ac96f53cc5492cb192223fe8a8b9862432c85"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#30acffc1cb8587ab50f1836ba91de847358040f4"
 dependencies = [
+ "derive_more",
  "frame-support",
  "log",
  "parity-scale-codec 2.3.1",
@@ -3543,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "kate"
 version = "0.2.1"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#552ac96f53cc5492cb192223fe8a8b9862432c85"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#30acffc1cb8587ab50f1836ba91de847358040f4"
 dependencies = [
  "bls12_381",
  "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
@@ -3569,13 +3570,15 @@ dependencies = [
 [[package]]
 name = "kate-recovery"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#552ac96f53cc5492cb192223fe8a8b9862432c85"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#30acffc1cb8587ab50f1836ba91de847358040f4"
 dependencies = [
+ "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
  "dusk-bytes",
  "dusk-plonk 0.12.0",
  "getrandom 0.2.7",
  "parity-scale-codec 3.2.1",
  "serde",
+ "sp-runtime",
  "thiserror",
 ]
 
@@ -4455,7 +4458,7 @@ checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 [[package]]
 name = "merkle"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#552ac96f53cc5492cb192223fe8a8b9862432c85"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#30acffc1cb8587ab50f1836ba91de847358040f4"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -4775,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "nomad-base"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#552ac96f53cc5492cb192223fe8a8b9862432c85"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#30acffc1cb8587ab50f1836ba91de847358040f4"
 dependencies = [
  "ethers-signers",
  "frame-support",
@@ -4796,7 +4799,7 @@ dependencies = [
 [[package]]
 name = "nomad-core"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#552ac96f53cc5492cb192223fe8a8b9862432c85"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#30acffc1cb8587ab50f1836ba91de847358040f4"
 dependencies = [
  "ethers-core",
  "ethers-signers",
@@ -8061,7 +8064,7 @@ dependencies = [
 [[package]]
 name = "signature"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#552ac96f53cc5492cb192223fe8a8b9862432c85"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#30acffc1cb8587ab50f1836ba91de847358040f4"
 dependencies = [
  "arrayvec 0.7.2",
  "elliptic-curve",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ name = "da-bridge"
 version = "1.0.0"
 dependencies = [
  "da-control",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1)",
+ "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",
@@ -1403,7 +1403,7 @@ dependencies = [
 name = "da-control"
 version = "1.0.0"
 dependencies = [
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1)",
+ "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -1443,7 +1443,7 @@ dependencies = [
 [[package]]
 name = "da-primitives"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1#17c8a30ab178418aa7f835a3798a7a495e77f2a2"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#552ac96f53cc5492cb192223fe8a8b9862432c85"
 dependencies = [
  "frame-support",
  "log",
@@ -1465,7 +1465,7 @@ version = "4.0.0"
 dependencies = [
  "da-bridge",
  "da-control",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1)",
+ "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
@@ -1540,7 +1540,7 @@ version = "1.0.0"
 dependencies = [
  "da-bridge",
  "da-control",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1)",
+ "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
  "da-runtime",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -2365,7 +2365,7 @@ name = "frame-executive"
 version = "4.0.0-dev"
 dependencies = [
  "da-control",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1)",
+ "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
  "frame-support",
  "frame-system",
  "hex-literal",
@@ -2465,7 +2465,7 @@ version = "4.0.0-dev"
 dependencies = [
  "criterion",
  "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.1.0)",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1)",
+ "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
  "frame-support",
  "hex-literal",
  "impl-trait-for-tuples",
@@ -2491,7 +2491,7 @@ dependencies = [
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
 dependencies = [
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1)",
+ "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -2707,7 +2707,7 @@ name = "fuzzing"
 version = "0.1.0"
 dependencies = [
  "afl",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1)",
+ "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
  "hex-literal",
  "kate 0.2.1",
  "kate-recovery",
@@ -3543,10 +3543,10 @@ dependencies = [
 [[package]]
 name = "kate"
 version = "0.2.1"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1#17c8a30ab178418aa7f835a3798a7a495e77f2a2"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#552ac96f53cc5492cb192223fe8a8b9862432c85"
 dependencies = [
  "bls12_381",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1)",
+ "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
  "dusk-bytes",
  "dusk-plonk 0.12.0",
  "frame-support",
@@ -3569,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "kate-recovery"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1#17c8a30ab178418aa7f835a3798a7a495e77f2a2"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#552ac96f53cc5492cb192223fe8a8b9862432c85"
 dependencies = [
  "dusk-bytes",
  "dusk-plonk 0.12.0",
@@ -3583,7 +3583,7 @@ dependencies = [
 name = "kate-rpc"
 version = "0.1.0"
 dependencies = [
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1)",
+ "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
@@ -4455,7 +4455,7 @@ checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 [[package]]
 name = "merkle"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1#17c8a30ab178418aa7f835a3798a7a495e77f2a2"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#552ac96f53cc5492cb192223fe8a8b9862432c85"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -4579,7 +4579,7 @@ name = "mocked-runtime"
 version = "1.0.0"
 dependencies = [
  "da-control",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1)",
+ "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
  "derive_more",
  "frame-support",
  "frame-system",
@@ -4775,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "nomad-base"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1#17c8a30ab178418aa7f835a3798a7a495e77f2a2"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#552ac96f53cc5492cb192223fe8a8b9862432c85"
 dependencies = [
  "ethers-signers",
  "frame-support",
@@ -4796,7 +4796,7 @@ dependencies = [
 [[package]]
 name = "nomad-core"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1#17c8a30ab178418aa7f835a3798a7a495e77f2a2"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#552ac96f53cc5492cb192223fe8a8b9862432c85"
 dependencies = [
  "ethers-core",
  "ethers-signers",
@@ -4819,7 +4819,7 @@ dependencies = [
 name = "nomad-home"
 version = "4.0.0-dev"
 dependencies = [
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1)",
+ "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
  "ethers-signers",
  "frame-benchmarking",
  "frame-support",
@@ -8061,7 +8061,7 @@ dependencies = [
 [[package]]
 name = "signature"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1#17c8a30ab178418aa7f835a3798a7a495e77f2a2"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#552ac96f53cc5492cb192223fe8a8b9862432c85"
 dependencies = [
  "arrayvec 0.7.2",
  "elliptic-curve",
@@ -9549,7 +9549,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -9687,7 +9687,7 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 name = "updater-manager"
 version = "1.0.0"
 dependencies = [
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.2.1)",
+ "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,8 +1426,8 @@ dependencies = [
 
 [[package]]
 name = "da-primitives"
-version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#87ffe63fa07868bdf6cb77be3451d98caf89f663"
+version = "0.2.0"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.0#d745fdb1eb506497790a56352181e85e83d8a7f8"
 dependencies = [
  "derive_more",
  "frame-support",
@@ -3460,8 +3460,8 @@ dependencies = [
 
 [[package]]
 name = "kate"
-version = "0.2.1"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#87ffe63fa07868bdf6cb77be3451d98caf89f663"
+version = "0.3.0"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.0#d745fdb1eb506497790a56352181e85e83d8a7f8"
 dependencies = [
  "bls12_381",
  "da-primitives",
@@ -3487,7 +3487,7 @@ dependencies = [
 [[package]]
 name = "kate-recovery"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#87ffe63fa07868bdf6cb77be3451d98caf89f663"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.0#d745fdb1eb506497790a56352181e85e83d8a7f8"
 dependencies = [
  "da-primitives",
  "dusk-bytes",
@@ -4375,7 +4375,7 @@ checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 [[package]]
 name = "merkle"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#87ffe63fa07868bdf6cb77be3451d98caf89f663"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.0#d745fdb1eb506497790a56352181e85e83d8a7f8"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -4695,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "nomad-base"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#87ffe63fa07868bdf6cb77be3451d98caf89f663"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.0#d745fdb1eb506497790a56352181e85e83d8a7f8"
 dependencies = [
  "ethers-signers",
  "frame-support",
@@ -4716,7 +4716,7 @@ dependencies = [
 [[package]]
 name = "nomad-core"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#87ffe63fa07868bdf6cb77be3451d98caf89f663"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.0#d745fdb1eb506497790a56352181e85e83d8a7f8"
 dependencies = [
  "ethers-core",
  "ethers-signers",
@@ -7981,7 +7981,7 @@ dependencies = [
 [[package]]
 name = "signature"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#87ffe63fa07868bdf6cb77be3451d98caf89f663"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.0#d745fdb1eb506497790a56352181e85e83d8a7f8"
 dependencies = [
  "arrayvec 0.7.2",
  "elliptic-curve",
@@ -9463,7 +9463,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,8 +1426,8 @@ dependencies = [
 
 [[package]]
 name = "da-primitives"
-version = "0.2.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.0#d745fdb1eb506497790a56352181e85e83d8a7f8"
+version = "0.2.1"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.1#483efa604978e1313b4e578584f0a5aa0464a9b0"
 dependencies = [
  "derive_more",
  "frame-support",
@@ -3460,8 +3460,8 @@ dependencies = [
 
 [[package]]
 name = "kate"
-version = "0.3.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.0#d745fdb1eb506497790a56352181e85e83d8a7f8"
+version = "0.3.1"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.1#483efa604978e1313b4e578584f0a5aa0464a9b0"
 dependencies = [
  "bls12_381",
  "da-primitives",
@@ -3486,16 +3486,14 @@ dependencies = [
 
 [[package]]
 name = "kate-recovery"
-version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.0#d745fdb1eb506497790a56352181e85e83d8a7f8"
+version = "0.1.1"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.1#483efa604978e1313b4e578584f0a5aa0464a9b0"
 dependencies = [
- "da-primitives",
  "dusk-bytes",
  "dusk-plonk",
  "getrandom 0.2.7",
  "parity-scale-codec 3.2.1",
  "serde",
- "sp-runtime",
  "thiserror",
 ]
 
@@ -4375,7 +4373,7 @@ checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 [[package]]
 name = "merkle"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.0#d745fdb1eb506497790a56352181e85e83d8a7f8"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.1#483efa604978e1313b4e578584f0a5aa0464a9b0"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -4695,7 +4693,7 @@ dependencies = [
 [[package]]
 name = "nomad-base"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.0#d745fdb1eb506497790a56352181e85e83d8a7f8"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.1#483efa604978e1313b4e578584f0a5aa0464a9b0"
 dependencies = [
  "ethers-signers",
  "frame-support",
@@ -4716,7 +4714,7 @@ dependencies = [
 [[package]]
 name = "nomad-core"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.0#d745fdb1eb506497790a56352181e85e83d8a7f8"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.1#483efa604978e1313b4e578584f0a5aa0464a9b0"
 dependencies = [
  "ethers-core",
  "ethers-signers",
@@ -7981,7 +7979,7 @@ dependencies = [
 [[package]]
 name = "signature"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.0#d745fdb1eb506497790a56352181e85e83d8a7f8"
+source = "git+https://github.com/maticnetwork/avail-core.git?tag=v0.2.1#483efa604978e1313b4e578584f0a5aa0464a9b0"
 dependencies = [
  "arrayvec 0.7.2",
  "elliptic-curve",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3517,6 +3517,7 @@ dependencies = [
  "sc-client-db",
  "sp-api",
  "sp-blockchain",
+ "sp-core",
  "sp-rpc",
  "sp-runtime",
  "sp-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,11 +73,11 @@ dependencies = [
 
 [[package]]
 name = "afl"
-version = "0.12.8"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14c4f38655ef328922eead1656bfe02aa91b5ff3cdb5dac8a3fd0d9b96e857d"
+checksum = "29d4b3411687df6020ec99478c56acd3c23b1caf0485575918f9c8852fda854d"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.17",
  "fs_extra",
  "libc",
  "rustc_version 0.4.0",
@@ -452,6 +452,11 @@ name = "bech32"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
+
+[[package]]
+name = "beefy-merkle-tree"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.13#afb74de23dfe2994e7ce38c0870efb9734e966f7"
 
 [[package]]
 name = "bimap"
@@ -894,32 +899,30 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
  "vec_map",
 ]
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "06badb543e734a2d6568e19a40af66ed5364360b9226184926f89d229b4b4267"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.15.1",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1375,7 +1378,7 @@ name = "da-bridge"
 version = "1.0.0"
 dependencies = [
  "da-control",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
+ "da-primitives",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",
@@ -1403,11 +1406,11 @@ dependencies = [
 name = "da-control"
 version = "1.0.0"
 dependencies = [
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
+ "da-primitives",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "kate 0.2.1",
+ "kate",
  "pallet-balances",
  "pallet-transaction-payment",
  "parity-scale-codec 2.3.1",
@@ -1424,26 +1427,7 @@ dependencies = [
 [[package]]
 name = "da-primitives"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.1.0#fab02ccbc260e88e511142023fbca102ff357284"
-dependencies = [
- "frame-support",
- "log",
- "parity-scale-codec 2.3.1",
- "parity-util-mem",
- "scale-info",
- "serde",
- "serde_json",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-runtime-interface",
- "sp-std",
-]
-
-[[package]]
-name = "da-primitives"
-version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#30acffc1cb8587ab50f1836ba91de847358040f4"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#87ffe63fa07868bdf6cb77be3451d98caf89f663"
 dependencies = [
  "derive_more",
  "frame-support",
@@ -1466,7 +1450,7 @@ version = "4.0.0"
 dependencies = [
  "da-bridge",
  "da-control",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
+ "da-primitives",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
@@ -1476,8 +1460,9 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "hex",
  "hex-literal",
- "kate 0.2.1",
+ "kate",
  "kate-rpc-runtime-api",
+ "log",
  "nomad-home",
  "pallet-asset-tx-payment",
  "pallet-authority-discovery",
@@ -1541,7 +1526,7 @@ version = "1.0.0"
 dependencies = [
  "da-bridge",
  "da-control",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
+ "da-primitives",
  "da-runtime",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -1553,7 +1538,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "kate 0.2.1",
+ "kate",
  "kate-rpc",
  "lru 0.7.8",
  "nomad-home",
@@ -1779,19 +1764,6 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "dusk-bls12_381"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22aa3d0bb1f8a54723a33b056022b2f71eca929a86e2e03653f18b9dff0b1b8"
-dependencies = [
- "byteorder",
- "dusk-bytes",
- "rand_core 0.6.4",
- "rayon",
- "subtle",
-]
-
-[[package]]
-name = "dusk-bls12_381"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e24fd566c9601db3afc08574e9592bac981d2adeca458439e1f06615f511ce09"
@@ -1814,42 +1786,14 @@ dependencies = [
 
 [[package]]
 name = "dusk-jubjub"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842f5a6811741a236f46d4b7cd9da8a21e435e3395b4c3878681e0bb8e38d6f"
-dependencies = [
- "dusk-bls12_381 0.8.0",
- "dusk-bytes",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "dusk-jubjub"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a6097b9d4dc11110f6dea84f7d3594736764a789ce16b17a7a492f5d5926e62"
 dependencies = [
- "dusk-bls12_381 0.11.0",
+ "dusk-bls12_381",
  "dusk-bytes",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "dusk-plonk"
-version = "0.8.2"
-source = "git+https://github.com/maticnetwork/plonk.git?branch=v0.8.2-polygon-5#df2eb98b7cd6958159b527891708c376c895f5b4"
-dependencies = [
- "cfg-if 1.0.0",
- "dusk-bls12_381 0.8.0",
- "dusk-bytes",
- "dusk-jubjub 0.10.1",
- "hashbrown 0.9.1",
- "itertools 0.9.0",
- "merlin 3.0.0",
- "rand_core 0.6.4",
- "rayon",
 ]
 
 [[package]]
@@ -1858,9 +1802,9 @@ version = "0.12.0"
 source = "git+https://github.com/maticnetwork/plonk.git?tag=v0.12.0-polygon-1#d8cdbd1787405ecceb494b9d1438254b1c1de53b"
 dependencies = [
  "cfg-if 1.0.0",
- "dusk-bls12_381 0.11.0",
+ "dusk-bls12_381",
  "dusk-bytes",
- "dusk-jubjub 0.12.0",
+ "dusk-jubjub",
  "hashbrown 0.9.1",
  "itertools 0.9.0",
  "merlin 3.0.0",
@@ -2366,7 +2310,7 @@ name = "frame-executive"
 version = "4.0.0-dev"
 dependencies = [
  "da-control",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
+ "da-primitives",
  "frame-support",
  "frame-system",
  "hex-literal",
@@ -2464,14 +2408,13 @@ dependencies = [
 name = "frame-system"
 version = "4.0.0-dev"
 dependencies = [
+ "beefy-merkle-tree",
  "criterion",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.1.0)",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
+ "da-primitives",
  "frame-support",
  "hex-literal",
  "impl-trait-for-tuples",
- "kate 0.1.0",
- "kate 0.2.1",
+ "kate",
  "log",
  "parity-scale-codec 2.3.1",
  "rs_merkle",
@@ -2492,7 +2435,7 @@ dependencies = [
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
 dependencies = [
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
+ "da-primitives",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -2708,9 +2651,9 @@ name = "fuzzing"
 version = "0.1.0"
 dependencies = [
  "afl",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
+ "da-primitives",
  "hex-literal",
- "kate 0.2.1",
+ "kate",
  "kate-recovery",
 ]
 
@@ -3517,39 +3460,13 @@ dependencies = [
 
 [[package]]
 name = "kate"
-version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.1.0#fab02ccbc260e88e511142023fbca102ff357284"
-dependencies = [
- "bls12_381",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?tag=kate/v0.1.0)",
- "dusk-bytes",
- "dusk-plonk 0.8.2",
- "frame-support",
- "getrandom 0.2.7",
- "hex",
- "log",
- "num_cpus",
- "once_cell",
- "parity-scale-codec 3.2.1",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.5.1",
- "rayon",
- "serde",
- "sp-core",
- "sp-std",
- "static_assertions",
-]
-
-[[package]]
-name = "kate"
 version = "0.2.1"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#30acffc1cb8587ab50f1836ba91de847358040f4"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#87ffe63fa07868bdf6cb77be3451d98caf89f663"
 dependencies = [
  "bls12_381",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
+ "da-primitives",
  "dusk-bytes",
- "dusk-plonk 0.12.0",
+ "dusk-plonk",
  "frame-support",
  "getrandom 0.2.7",
  "hex",
@@ -3570,11 +3487,11 @@ dependencies = [
 [[package]]
 name = "kate-recovery"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#30acffc1cb8587ab50f1836ba91de847358040f4"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#87ffe63fa07868bdf6cb77be3451d98caf89f663"
 dependencies = [
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
+ "da-primitives",
  "dusk-bytes",
- "dusk-plonk 0.12.0",
+ "dusk-plonk",
  "getrandom 0.2.7",
  "parity-scale-codec 3.2.1",
  "serde",
@@ -3586,14 +3503,14 @@ dependencies = [
 name = "kate-rpc"
 version = "0.1.0"
 dependencies = [
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
+ "da-primitives",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
- "kate 0.2.1",
+ "kate",
  "kate-rpc-runtime-api",
  "lru 0.7.8",
  "parity-scale-codec 2.3.1",
@@ -4458,7 +4375,7 @@ checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 [[package]]
 name = "merkle"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#30acffc1cb8587ab50f1836ba91de847358040f4"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#87ffe63fa07868bdf6cb77be3451d98caf89f663"
 dependencies = [
  "frame-support",
  "hex-literal",
@@ -4582,11 +4499,11 @@ name = "mocked-runtime"
 version = "1.0.0"
 dependencies = [
  "da-control",
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
+ "da-primitives",
  "derive_more",
  "frame-support",
  "frame-system",
- "kate 0.2.1",
+ "kate",
  "pallet-babe",
  "pallet-balances",
  "pallet-staking",
@@ -4778,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "nomad-base"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#30acffc1cb8587ab50f1836ba91de847358040f4"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#87ffe63fa07868bdf6cb77be3451d98caf89f663"
 dependencies = [
  "ethers-signers",
  "frame-support",
@@ -4799,7 +4716,7 @@ dependencies = [
 [[package]]
 name = "nomad-core"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#30acffc1cb8587ab50f1836ba91de847358040f4"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#87ffe63fa07868bdf6cb77be3451d98caf89f663"
 dependencies = [
  "ethers-core",
  "ethers-signers",
@@ -4822,7 +4739,7 @@ dependencies = [
 name = "nomad-home"
 version = "4.0.0-dev"
 dependencies = [
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
+ "da-primitives",
  "ethers-signers",
  "frame-benchmarking",
  "frame-support",
@@ -8064,7 +7981,7 @@ dependencies = [
 [[package]]
 name = "signature"
 version = "0.1.0"
-source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#30acffc1cb8587ab50f1836ba91de847358040f4"
+source = "git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11#87ffe63fa07868bdf6cb77be3451d98caf89f663"
 dependencies = [
  "arrayvec 0.7.2",
  "elliptic-curve",
@@ -9172,12 +9089,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
-
-[[package]]
 name = "thiserror"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9552,7 +9463,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -9690,7 +9601,7 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 name = "updater-manager"
 version = "1.0.0"
 dependencies = [
- "da-primitives 0.1.0 (git+https://github.com/maticnetwork/avail-core.git?branch=miguel/ava-397-compatibility-issue-between-10-11)",
+ "da-primitives",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 
 [dependencies]
 afl = "*"
-kate-recovery = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11" }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11" }
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+kate-recovery = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0" }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0" }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
 hex-literal = "0.3.1"
 
 [[bin]]

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 
 [dependencies]
 afl = "*"
-kate-recovery = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1" }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1" }
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
+kate-recovery = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11" }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11" }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
 hex-literal = "0.3.1"
 
 [[bin]]

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 
 [dependencies]
 afl = "*"
-kate-recovery = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0" }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0" }
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+kate-recovery = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1" }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1" }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
 hex-literal = "0.3.1"
 
 [[bin]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,8 +18,8 @@ name = "data-avail"
 
 [dependencies]
 # Internals
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
 da-runtime = { path = "../runtime" }
 da-control = { path = "../pallets/dactr" }
 kate-rpc = { path = "../rpc/kate-rpc" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,8 +18,8 @@ name = "data-avail"
 
 [dependencies]
 # Internals
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
 da-runtime = { path = "../runtime" }
 da-control = { path = "../pallets/dactr" }
 kate-rpc = { path = "../rpc/kate-rpc" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,8 +18,8 @@ name = "data-avail"
 
 [dependencies]
 # Internals
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
 da-runtime = { path = "../runtime" }
 da-control = { path = "../pallets/dactr" }
 kate-rpc = { path = "../rpc/kate-rpc" }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -253,12 +253,16 @@ pub fn testnet_genesis(
 			keys: initial_authorities
 				.iter()
 				.map(|x| {
-					(x.0.clone(), x.0.clone(), SessionKeys {
-						grandpa: x.2.clone(),
-						babe: x.3.clone(),
-						im_online: x.4.clone(),
-						authority_discovery: x.5.clone(),
-					})
+					(
+						x.0.clone(),
+						x.0.clone(),
+						SessionKeys {
+							grandpa: x.2.clone(),
+							babe: x.3.clone(),
+							im_online: x.4.clone(),
+							authority_discovery: x.5.clone(),
+						},
+					)
 				})
 				.collect::<Vec<_>>(),
 		},
@@ -306,18 +310,27 @@ pub fn testnet_genesis(
 		transaction_payment: Default::default(),
 		data_availability: DataAvailabilityConfig {
 			app_keys: vec![
-				(b"Data Avail".to_vec(), AppKeyInfo {
-					owner: root_key.clone(),
-					id: 0,
-				}),
-				(b"Ethereum".to_vec(), AppKeyInfo {
-					owner: root_key.clone(),
-					id: 1,
-				}),
-				(b"Polygon".to_vec(), AppKeyInfo {
-					owner: root_key,
-					id: 2,
-				}),
+				(
+					b"Data Avail".to_vec(),
+					AppKeyInfo {
+						owner: root_key.clone(),
+						id: 0.into(),
+					},
+				),
+				(
+					b"Ethereum".to_vec(),
+					AppKeyInfo {
+						owner: root_key.clone(),
+						id: 1.into(),
+					},
+				),
+				(
+					b"Polygon".to_vec(),
+					AppKeyInfo {
+						owner: root_key,
+						id: 2.into(),
+					},
+				),
 			],
 		},
 		updater_manager: UpdaterManagerConfig {
@@ -475,18 +488,27 @@ fn genesis_builder(
 		transaction_payment: Default::default(),
 		data_availability: DataAvailabilityConfig {
 			app_keys: vec![
-				(b"Data Avail".to_vec(), AppKeyInfo {
-					owner: sudo_key.clone(),
-					id: 0,
-				}),
-				(b"Ethereum".to_vec(), AppKeyInfo {
-					owner: sudo_key.clone(),
-					id: 1,
-				}),
-				(b"Polygon".to_vec(), AppKeyInfo {
-					owner: sudo_key,
-					id: 2,
-				}),
+				(
+					b"Data Avail".to_vec(),
+					AppKeyInfo {
+						owner: sudo_key.clone(),
+						id: 0.into(),
+					},
+				),
+				(
+					b"Ethereum".to_vec(),
+					AppKeyInfo {
+						owner: sudo_key.clone(),
+						id: 1.into(),
+					},
+				),
+				(
+					b"Polygon".to_vec(),
+					AppKeyInfo {
+						owner: sudo_key,
+						id: 2.into(),
+					},
+				),
 			],
 		},
 		updater_manager: Default::default(),
@@ -591,9 +613,13 @@ pub(crate) mod tests {
 
 	#[test]
 	#[ignore]
-	fn test_create_development_chain_spec() { development_config().build_storage().unwrap(); }
+	fn test_create_development_chain_spec() {
+		development_config().build_storage().unwrap();
+	}
 
 	#[test]
 	#[ignore]
-	fn test_create_local_testnet_chain_spec() { testnet_config().build_storage().unwrap(); }
+	fn test_create_local_testnet_chain_spec() {
+		testnet_config().build_storage().unwrap();
+	}
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -253,16 +253,12 @@ pub fn testnet_genesis(
 			keys: initial_authorities
 				.iter()
 				.map(|x| {
-					(
-						x.0.clone(),
-						x.0.clone(),
-						SessionKeys {
-							grandpa: x.2.clone(),
-							babe: x.3.clone(),
-							im_online: x.4.clone(),
-							authority_discovery: x.5.clone(),
-						},
-					)
+					(x.0.clone(), x.0.clone(), SessionKeys {
+						grandpa: x.2.clone(),
+						babe: x.3.clone(),
+						im_online: x.4.clone(),
+						authority_discovery: x.5.clone(),
+					})
 				})
 				.collect::<Vec<_>>(),
 		},
@@ -310,27 +306,18 @@ pub fn testnet_genesis(
 		transaction_payment: Default::default(),
 		data_availability: DataAvailabilityConfig {
 			app_keys: vec![
-				(
-					b"Data Avail".to_vec(),
-					AppKeyInfo {
-						owner: root_key.clone(),
-						id: 0.into(),
-					},
-				),
-				(
-					b"Ethereum".to_vec(),
-					AppKeyInfo {
-						owner: root_key.clone(),
-						id: 1.into(),
-					},
-				),
-				(
-					b"Polygon".to_vec(),
-					AppKeyInfo {
-						owner: root_key,
-						id: 2.into(),
-					},
-				),
+				(b"Data Avail".to_vec(), AppKeyInfo {
+					owner: root_key.clone(),
+					id: 0.into(),
+				}),
+				(b"Ethereum".to_vec(), AppKeyInfo {
+					owner: root_key.clone(),
+					id: 1.into(),
+				}),
+				(b"Polygon".to_vec(), AppKeyInfo {
+					owner: root_key,
+					id: 2.into(),
+				}),
 			],
 		},
 		updater_manager: UpdaterManagerConfig {
@@ -488,27 +475,18 @@ fn genesis_builder(
 		transaction_payment: Default::default(),
 		data_availability: DataAvailabilityConfig {
 			app_keys: vec![
-				(
-					b"Data Avail".to_vec(),
-					AppKeyInfo {
-						owner: sudo_key.clone(),
-						id: 0.into(),
-					},
-				),
-				(
-					b"Ethereum".to_vec(),
-					AppKeyInfo {
-						owner: sudo_key.clone(),
-						id: 1.into(),
-					},
-				),
-				(
-					b"Polygon".to_vec(),
-					AppKeyInfo {
-						owner: sudo_key,
-						id: 2.into(),
-					},
-				),
+				(b"Data Avail".to_vec(), AppKeyInfo {
+					owner: sudo_key.clone(),
+					id: 0.into(),
+				}),
+				(b"Ethereum".to_vec(), AppKeyInfo {
+					owner: sudo_key.clone(),
+					id: 1.into(),
+				}),
+				(b"Polygon".to_vec(), AppKeyInfo {
+					owner: sudo_key,
+					id: 2.into(),
+				}),
 			],
 		},
 		updater_manager: Default::default(),
@@ -613,13 +591,9 @@ pub(crate) mod tests {
 
 	#[test]
 	#[ignore]
-	fn test_create_development_chain_spec() {
-		development_config().build_storage().unwrap();
-	}
+	fn test_create_development_chain_spec() { development_config().build_storage().unwrap(); }
 
 	#[test]
 	#[ignore]
-	fn test_create_local_testnet_chain_spec() {
-		testnet_config().build_storage().unwrap();
-	}
+	fn test_create_local_testnet_chain_spec() { testnet_config().build_storage().unwrap(); }
 }

--- a/pallets/dactr/Cargo.toml
+++ b/pallets/dactr/Cargo.toml
@@ -12,8 +12,8 @@ description = "Data Avail Control Module"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
 
 # Substrate
 serde = { version = "1.0.126", optional = true, features = ["derive"] }

--- a/pallets/dactr/Cargo.toml
+++ b/pallets/dactr/Cargo.toml
@@ -12,8 +12,8 @@ description = "Data Avail Control Module"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
 
 # Substrate
 serde = { version = "1.0.126", optional = true, features = ["derive"] }

--- a/pallets/dactr/Cargo.toml
+++ b/pallets/dactr/Cargo.toml
@@ -12,8 +12,8 @@ description = "Data Avail Control Module"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
 
 # Substrate
 serde = { version = "1.0.126", optional = true, features = ["derive"] }

--- a/pallets/dactr/src/benchmarking.rs
+++ b/pallets/dactr/src/benchmarking.rs
@@ -30,7 +30,7 @@ benchmarks! {
 	}: create_application_key(origin, key)
 	verify {
 		let info = Pallet::<T>::application_key(&key_verify);
-		assert_eq!( info, Some(AppKeyInfoFor::<T> { owner: caller, id: 3u32 }));
+		assert_eq!( info, Some(AppKeyInfoFor::<T> { owner: caller, id: 3.into()}));
 	}
 
 	submit_data {

--- a/pallets/dactr/src/extensions/check_app_id.rs
+++ b/pallets/dactr/src/extensions/check_app_id.rs
@@ -35,9 +35,7 @@ where
 	T::Call: IsSubType<DACall<T>>,
 {
 	/// utility constructor. Used only in client/factory code.
-	pub fn from(app_id: AppId) -> Self {
-		Self(app_id, sp_std::marker::PhantomData)
-	}
+	pub fn from(app_id: AppId) -> Self { Self(app_id, sp_std::marker::PhantomData) }
 
 	/// Transaction validation:
 	///  - Only `DataAvailability::submit_data(..)` extrinsic can use `AppId != 0`. Any other call
@@ -66,9 +64,7 @@ where
 	}
 }
 impl<T: Config + Send + Sync> Default for CheckAppId<T> {
-	fn default() -> Self {
-		Self(AppId::default(), PhantomData)
-	}
+	fn default() -> Self { Self(AppId::default(), PhantomData) }
 }
 
 impl<T> Debug for CheckAppId<T>
@@ -76,14 +72,10 @@ where
 	T: Config + Send + Sync,
 {
 	#[cfg(feature = "std")]
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		write!(f, "CheckAppId: {}", self.0)
-	}
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result { write!(f, "CheckAppId: {}", self.0) }
 
 	#[cfg(not(feature = "std"))]
-	fn fmt(&self, _: &mut Formatter) -> fmt::Result {
-		Ok(())
-	}
+	fn fmt(&self, _: &mut Formatter) -> fmt::Result { Ok(()) }
 }
 
 impl<T> SignedExtension for CheckAppId<T>
@@ -118,9 +110,7 @@ where
 	T: Config + Send + Sync,
 {
 	#[inline]
-	fn app_id(&self) -> AppId {
-		self.0
-	}
+	fn app_id(&self) -> AppId { self.0 }
 }
 
 #[cfg(test)]
@@ -136,9 +126,7 @@ mod tests {
 		pallet::Call as DACall,
 	};
 
-	fn remark_call() -> Call {
-		Call::System(SysCall::remark { remark: vec![] })
-	}
+	fn remark_call() -> Call { Call::System(SysCall::remark { remark: vec![] }) }
 
 	fn submit_data_call() -> Call {
 		Call::DataAvailability(DACall::submit_data {

--- a/pallets/dactr/src/lib.rs
+++ b/pallets/dactr/src/lib.rs
@@ -204,7 +204,9 @@ pub mod pallet {
 
 	#[cfg(feature = "std")]
 	impl<T: Config> Default for GenesisConfig<T> {
-		fn default() -> Self { Self { app_keys: vec![] } }
+		fn default() -> Self {
+			Self { app_keys: vec![] }
+		}
 	}
 
 	#[pallet::genesis_build]
@@ -238,10 +240,11 @@ pub mod pallet {
 				.iter()
 				.max()
 				.cloned()
-				.unwrap_or(0)
-				.checked_add(1)
+				.map(Into::into)
+				.unwrap_or(0u32)
+				.checked_add(1u32)
 				.expect("DA Control Genesis overflows the last application id");
-			NextAppId::<T>::put(last_id);
+			NextAppId::<T>::put::<AppId>(last_id.into());
 		}
 	}
 
@@ -267,7 +270,7 @@ impl<T: Config> Pallet<T> {
 	/// Returns the latest available application ID and increases it.
 	pub fn next_application_id() -> Result<AppId, Error<T>> {
 		NextAppId::<T>::try_mutate(|id| {
-			let new_id = id.checked_add(1).ok_or(Error::<T>::LastAppIdOverflowed)?;
+			let new_id = AppId(id.0.checked_add(1).ok_or(Error::<T>::LastAppIdOverflowed)?);
 			Ok(replace(id, new_id))
 		})
 	}

--- a/pallets/dactr/src/lib.rs
+++ b/pallets/dactr/src/lib.rs
@@ -204,9 +204,7 @@ pub mod pallet {
 
 	#[cfg(feature = "std")]
 	impl<T: Config> Default for GenesisConfig<T> {
-		fn default() -> Self {
-			Self { app_keys: vec![] }
-		}
+		fn default() -> Self { Self { app_keys: vec![] } }
 	}
 
 	#[pallet::genesis_build]

--- a/pallets/dactr/src/mock.rs
+++ b/pallets/dactr/src/mock.rs
@@ -141,9 +141,27 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
 	da_control::GenesisConfig::<Test> {
 		app_keys: vec![
-			(b"Data Avail".to_vec(), AppKeyInfo { owner: 1, id: 0 }),
-			(b"Ethereum".to_vec(), AppKeyInfo { owner: 2, id: 1 }),
-			(b"Polygon".to_vec(), AppKeyInfo { owner: 2, id: 2 }),
+			(
+				b"Data Avail".to_vec(),
+				AppKeyInfo {
+					owner: 1,
+					id: 0.into(),
+				},
+			),
+			(
+				b"Ethereum".to_vec(),
+				AppKeyInfo {
+					owner: 2,
+					id: 1.into(),
+				},
+			),
+			(
+				b"Polygon".to_vec(),
+				AppKeyInfo {
+					owner: 2,
+					id: 2.into(),
+				},
+			),
 		],
 	}
 	.assimilate_storage(&mut storage)

--- a/pallets/dactr/src/mock.rs
+++ b/pallets/dactr/src/mock.rs
@@ -5,6 +5,7 @@ use da_primitives::{
 	Header,
 };
 use frame_support::{parameter_types, weights::IdentityFee};
+use frame_system::{DRFCallOf, DRFOutput, DataRootFilter};
 use pallet_transaction_payment::CurrencyAdapter;
 use sp_core::H256;
 use sp_runtime::{
@@ -50,6 +51,12 @@ parameter_types! {
 	pub static ExistentialDeposit: u64 = 0;
 }
 
+impl DataRootFilter for Test {
+	type UncheckedExtrinsic = UncheckedExtrinsic<Test>;
+
+	fn filter(_call: &DRFCallOf<Self::UncheckedExtrinsic>) -> DRFOutput { None }
+}
+
 impl frame_system::Config for Test {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	type AccountId = u64;
@@ -59,12 +66,13 @@ impl frame_system::Config for Test {
 	type BlockNumber = BlockNumber;
 	type BlockWeights = BlockWeights;
 	type Call = Call;
+	type DataRootBuilderFilter = Test;
 	type DbWeight = ();
 	type Event = Event;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Header = Header<Self::BlockNumber, BlakeTwo256>;
-	type HeaderBuilder = frame_system::header_builder::da::HeaderBuilder<Test>;
+	type HeaderExtensionBuilder = frame_system::header_builder::da::HeaderExtensionBuilder<Test>;
 	type Index = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type OnKilledAccount = ();
@@ -141,27 +149,18 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
 	da_control::GenesisConfig::<Test> {
 		app_keys: vec![
-			(
-				b"Data Avail".to_vec(),
-				AppKeyInfo {
-					owner: 1,
-					id: 0.into(),
-				},
-			),
-			(
-				b"Ethereum".to_vec(),
-				AppKeyInfo {
-					owner: 2,
-					id: 1.into(),
-				},
-			),
-			(
-				b"Polygon".to_vec(),
-				AppKeyInfo {
-					owner: 2,
-					id: 2.into(),
-				},
-			),
+			(b"Data Avail".to_vec(), AppKeyInfo {
+				owner: 1,
+				id: 0.into(),
+			}),
+			(b"Ethereum".to_vec(), AppKeyInfo {
+				owner: 2,
+				id: 1.into(),
+			}),
+			(b"Polygon".to_vec(), AppKeyInfo {
+				owner: 2,
+				id: 2.into(),
+			}),
 		],
 	}
 	.assimilate_storage(&mut storage)

--- a/pallets/dactr/src/tests.rs
+++ b/pallets/dactr/src/tests.rs
@@ -25,7 +25,10 @@ fn create_application_keys() {
 		);
 		assert_eq!(
 			DataAvailability::application_key(&new_key),
-			Some(AppKeyInfoFor::<Test> { id: 3, owner: 3 })
+			Some(AppKeyInfoFor::<Test> {
+				id: 3.into(),
+				owner: 3
+			})
 		);
 	})
 }

--- a/pallets/executive/Cargo.toml
+++ b/pallets/executive/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
 
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [
 	"derive",

--- a/pallets/executive/Cargo.toml
+++ b/pallets/executive/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
 
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [
 	"derive",

--- a/pallets/executive/Cargo.toml
+++ b/pallets/executive/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
 
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [
 	"derive",

--- a/pallets/executive/src/lib.rs
+++ b/pallets/executive/src/lib.rs
@@ -777,7 +777,7 @@ mod tests {
 			..Default::default()
 		});
 		let state_root =
-			hex!("f9ab7b81043ce843b6dcea19e9866b62b1dfcd652d6cae1d7e896d5d3001e112").into();
+			hex!("162ed31f8ac16b3e297cf35ee950fc6e11dddf90faebdc57f6a8c0e510fa5a9a").into();
 		let extrinsics_root =
 			hex!("03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314").into();
 

--- a/pallets/mocked_runtime/Cargo.toml
+++ b/pallets/mocked_runtime/Cargo.toml
@@ -9,8 +9,8 @@ repository = ""
 description = "Mokend Runtime for Testing"
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
 da-control = { path = "../dactr" }
 
 scale-info = { version = "1.0", features = ["derive"] }

--- a/pallets/mocked_runtime/Cargo.toml
+++ b/pallets/mocked_runtime/Cargo.toml
@@ -9,8 +9,8 @@ repository = ""
 description = "Mokend Runtime for Testing"
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
 da-control = { path = "../dactr" }
 
 scale-info = { version = "1.0", features = ["derive"] }

--- a/pallets/mocked_runtime/Cargo.toml
+++ b/pallets/mocked_runtime/Cargo.toml
@@ -9,8 +9,8 @@ repository = ""
 description = "Mokend Runtime for Testing"
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
 da-control = { path = "../dactr" }
 
 scale-info = { version = "1.0", features = ["derive"] }

--- a/pallets/mocked_runtime/src/lib.rs
+++ b/pallets/mocked_runtime/src/lib.rs
@@ -4,7 +4,7 @@ use frame_support::{
 	traits::{Get, Randomness},
 	weights::{constants::WEIGHT_PER_SECOND, IdentityFee, RuntimeDbWeight, Weight},
 };
-use frame_system::{CheckEra, CheckNonce, CheckWeight};
+use frame_system::{CheckEra, CheckNonce, CheckWeight, DRFCallOf, DRFOutput, DataRootFilter};
 use pallet_transaction_payment::CurrencyAdapter;
 use sp_runtime::{
 	generic::Block as SPBlock,
@@ -125,6 +125,12 @@ thread_local! {
 // Runtime
 //
 
+impl DataRootFilter for Runtime {
+	type UncheckedExtrinsic = UncheckedExtrinsic;
+
+	fn filter(_call: &DRFCallOf<Self::UncheckedExtrinsic>) -> DRFOutput { None }
+}
+
 impl frame_system::Config for Runtime {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	type AccountId = AccountId;
@@ -134,12 +140,13 @@ impl frame_system::Config for Runtime {
 	type BlockNumber = BlockNumber;
 	type BlockWeights = BlockWeights;
 	type Call = Call;
+	type DataRootBuilderFilter = Runtime;
 	type DbWeight = ();
 	type Event = Event;
 	type Hash = sp_core::H256;
 	type Hashing = BlakeTwo256;
 	type Header = da_primitives::Header<Self::BlockNumber, Self::Hashing>;
-	type HeaderBuilder = frame_system::header_builder::da::HeaderBuilder<Runtime>;
+	type HeaderExtensionBuilder = frame_system::header_builder::da::HeaderExtensionBuilder<Runtime>;
 	type Index = u64;
 	type Lookup = IdentityLookup<u64>;
 	type OnKilledAccount = ();

--- a/pallets/mocked_runtime/src/test_xt.rs
+++ b/pallets/mocked_runtime/src/test_xt.rs
@@ -45,26 +45,20 @@ where
 }
 
 impl<Call, Extra> Debug for TestXt<Call, Extra> {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		self.0.fmt(f)
-	}
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.0.fmt(f) }
 }
 
 impl<Call: Codec + Sync + Send, Context, Extra> Checkable<Context> for TestXt<Call, Extra> {
 	type Checked = Self;
 
-	fn check(self, _: &Context) -> Result<Self::Checked, TransactionValidityError> {
-		Ok(self)
-	}
+	fn check(self, _: &Context) -> Result<Self::Checked, TransactionValidityError> { Ok(self) }
 }
 
 impl<Call: Codec + Sync + Send, Extra> Extrinsic for TestXt<Call, Extra> {
 	type Call = Call;
 	type SignaturePayload = (u64, Extra);
 
-	fn is_signed(&self) -> Option<bool> {
-		self.0.is_signed()
-	}
+	fn is_signed(&self) -> Option<bool> { self.0.is_signed() }
 
 	fn new(c: Call, sig: Option<Self::SignaturePayload>) -> Option<Self> {
 		let sp_test = SPTestXt::<Call, Extra>::new(c, sig);
@@ -116,19 +110,13 @@ impl<Call, Extra> ExtrinsicCall for TestXt<Call, Extra>
 where
 	Call: Codec + Sync + Send,
 {
-	fn call(&self) -> &Self::Call {
-		self.0.call()
-	}
+	fn call(&self) -> &Self::Call { self.0.call() }
 }
 
 impl<Call, Extra> GetAppId for TestXt<Call, Extra> {
-	fn app_id(&self) -> AppId {
-		AppId::default()
-	}
+	fn app_id(&self) -> AppId { AppId::default() }
 }
 
 impl<Call: GetDispatchInfo, Extra> GetDispatchInfo for TestXt<Call, Extra> {
-	fn get_dispatch_info(&self) -> DispatchInfo {
-		self.0.call.get_dispatch_info()
-	}
+	fn get_dispatch_info(&self) -> DispatchInfo { self.0.call.get_dispatch_info() }
 }

--- a/pallets/mocked_runtime/src/test_xt.rs
+++ b/pallets/mocked_runtime/src/test_xt.rs
@@ -45,20 +45,26 @@ where
 }
 
 impl<Call, Extra> Debug for TestXt<Call, Extra> {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.0.fmt(f) }
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		self.0.fmt(f)
+	}
 }
 
 impl<Call: Codec + Sync + Send, Context, Extra> Checkable<Context> for TestXt<Call, Extra> {
 	type Checked = Self;
 
-	fn check(self, _: &Context) -> Result<Self::Checked, TransactionValidityError> { Ok(self) }
+	fn check(self, _: &Context) -> Result<Self::Checked, TransactionValidityError> {
+		Ok(self)
+	}
 }
 
 impl<Call: Codec + Sync + Send, Extra> Extrinsic for TestXt<Call, Extra> {
 	type Call = Call;
 	type SignaturePayload = (u64, Extra);
 
-	fn is_signed(&self) -> Option<bool> { self.0.is_signed() }
+	fn is_signed(&self) -> Option<bool> {
+		self.0.is_signed()
+	}
 
 	fn new(c: Call, sig: Option<Self::SignaturePayload>) -> Option<Self> {
 		let sp_test = SPTestXt::<Call, Extra>::new(c, sig);
@@ -110,13 +116,19 @@ impl<Call, Extra> ExtrinsicCall for TestXt<Call, Extra>
 where
 	Call: Codec + Sync + Send,
 {
-	fn call(&self) -> &Self::Call { self.0.call() }
+	fn call(&self) -> &Self::Call {
+		self.0.call()
+	}
 }
 
-impl<Call, Extra> GetAppId<AppId> for TestXt<Call, Extra> {
-	fn app_id(&self) -> AppId { AppId::default() }
+impl<Call, Extra> GetAppId for TestXt<Call, Extra> {
+	fn app_id(&self) -> AppId {
+		AppId::default()
+	}
 }
 
 impl<Call: GetDispatchInfo, Extra> GetDispatchInfo for TestXt<Call, Extra> {
-	fn get_dispatch_info(&self) -> DispatchInfo { self.0.call.get_dispatch_info() }
+	fn get_dispatch_info(&self) -> DispatchInfo {
+		self.0.call.get_dispatch_info()
+	}
 }

--- a/pallets/nomad/da-bridge/Cargo.toml
+++ b/pallets/nomad/da-bridge/Cargo.toml
@@ -13,8 +13,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # Our crates
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
-nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
 nomad-home = { path = "../home", default-features = false }
 
 # 3rd-party 
@@ -39,8 +39,8 @@ hex-literal = "0.3.4"
 frame-executive = { version = "4.0.0-dev" }
 pallet-transaction-payment = { version = "4.0.0-dev" }
 da-control = { path = "../../dactr" }
-nomad-base = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11" }
-merkle  = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11" }
+nomad-base = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0" }
+merkle  = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0" }
 updater-manager = { path = "../updater-manager" }
 
 [features]

--- a/pallets/nomad/da-bridge/Cargo.toml
+++ b/pallets/nomad/da-bridge/Cargo.toml
@@ -13,8 +13,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # Our crates
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
-nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
 nomad-home = { path = "../home", default-features = false }
 
 # 3rd-party 
@@ -39,8 +39,8 @@ hex-literal = "0.3.4"
 frame-executive = { version = "4.0.0-dev" }
 pallet-transaction-payment = { version = "4.0.0-dev" }
 da-control = { path = "../../dactr" }
-nomad-base = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1" }
-merkle  = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1" }
+nomad-base = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11" }
+merkle  = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11" }
 updater-manager = { path = "../updater-manager" }
 
 [features]

--- a/pallets/nomad/da-bridge/Cargo.toml
+++ b/pallets/nomad/da-bridge/Cargo.toml
@@ -13,8 +13,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # Our crates
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
-nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
+nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
 nomad-home = { path = "../home", default-features = false }
 
 # 3rd-party 
@@ -39,8 +39,8 @@ hex-literal = "0.3.4"
 frame-executive = { version = "4.0.0-dev" }
 pallet-transaction-payment = { version = "4.0.0-dev" }
 da-control = { path = "../../dactr" }
-nomad-base = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0" }
-merkle  = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0" }
+nomad-base = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1" }
+merkle  = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1" }
 updater-manager = { path = "../updater-manager" }
 
 [features]

--- a/pallets/nomad/da-bridge/src/benchmarking.rs
+++ b/pallets/nomad/da-bridge/src/benchmarking.rs
@@ -1,11 +1,10 @@
-use da_primitives::{traits::ExtendedHeader, HeaderNumberTrait, KateCommitment};
+use da_primitives::traits::ExtendedHeader;
 use frame_benchmarking::{benchmarks, whitelisted_caller};
 use frame_system::{BlockHash, RawOrigin};
 use hex_literal::hex;
 use nomad_home::Nonces;
 use sp_core::H256;
-use sp_runtime::{traits::Header as _, Digest};
-use sp_std::vec;
+use sp_runtime::traits::Header as _;
 
 use crate::*;
 
@@ -15,30 +14,29 @@ benchmarks! {
 			[u8; 32]: From<<T as frame_system::Config>::AccountId>,
 			H256: From<<T as frame_system::Config>::Hash>,
 			H256: Into<<T as frame_system::Config>::Hash>,
-			<T as frame_system::Config>::BlockNumber: HeaderNumberTrait,
 			u32: From<<T as frame_system::Config>::BlockNumber>,
 			T::Header: ExtendedHeader,
-			<<T as frame_system::Config>::Header as ExtendedHeader>::Root: From<KateCommitment<H256>>
-			// <T as frame_system::Config>::Hash: From<KateCommitment<H256>>,
+			<T as frame_system::Config>::Hash: From<H256>,
 	}
 
 	try_dispatch_data_root {
 		// Create extrinsics root for block 10
-		let hash :H256 = hex!("03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314").into();
-		let extrinsics_root = KateCommitment { hash, ..Default::default() };
+		let extrinsics_root :H256 = hex!("03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314").into();
 
 		// Create block header for block 10
 		let block_number :T::BlockNumber = 10u32.into();
 		let state_root = H256::repeat_byte(2u8).into();
 		let parent_hash = H256::repeat_byte(1u8).into();
-		let app_data_lookup = Default::default();
-		let header :T::Header = ExtendedHeader::new(
+		let extension = Default::default();
+		let digest = Default::default();
+
+		let header = <T::Header as ExtendedHeader>::new(
 			block_number.clone(),
 			extrinsics_root.into(),
 			state_root,
 			parent_hash,
-			Digest { logs: vec![] },
-			app_data_lookup);
+			digest,
+			extension);
 		let header_hash :T::Hash = header.hash();
 
 		// Insert 10th block's hash into block number --> hash mapping so

--- a/pallets/nomad/da-bridge/src/lib.rs
+++ b/pallets/nomad/da-bridge/src/lib.rs
@@ -50,9 +50,7 @@ pub mod pallet {
 
 	#[cfg(feature = "std")]
 	impl Default for GenesisConfig {
-		fn default() -> Self {
-			Self {}
-		}
+		fn default() -> Self { Self {} }
 	}
 
 	#[pallet::genesis_build]

--- a/pallets/nomad/da-bridge/src/lib.rs
+++ b/pallets/nomad/da-bridge/src/lib.rs
@@ -50,7 +50,9 @@ pub mod pallet {
 
 	#[cfg(feature = "std")]
 	impl Default for GenesisConfig {
-		fn default() -> Self { Self {} }
+		fn default() -> Self {
+			Self {}
+		}
 	}
 
 	#[pallet::genesis_build]
@@ -110,7 +112,7 @@ pub mod pallet {
 			header: T::Header,
 		) -> DispatchResult {
 			let block_number = *header.number();
-			let data_root = header.data_root();
+			let data_root = header.extension().data_root();
 
 			let message: DABridgeMessages = DataRootMessage {
 				block_number: block_number.into(),

--- a/pallets/nomad/da-bridge/src/mock.rs
+++ b/pallets/nomad/da-bridge/src/mock.rs
@@ -1,6 +1,6 @@
 use da_primitives::Header;
 use frame_support::traits::GenesisBuild;
-use frame_system as system;
+use frame_system::{self as system, DRFCallOf, DRFOutput, DataRootFilter};
 use nomad_base::NomadBase;
 use primitive_types::{H160, H256};
 use sp_runtime::{
@@ -37,6 +37,12 @@ frame_support::parameter_types! {
 	pub static ExistentialDeposit: u64 = 0;
 }
 
+impl DataRootFilter for Test {
+	type UncheckedExtrinsic = UncheckedExtrinsic;
+
+	fn filter(_call: &DRFCallOf<Self::UncheckedExtrinsic>) -> DRFOutput { None }
+}
+
 impl system::Config for Test {
 	type AccountData = ();
 	type AccountId = AccountId32;
@@ -46,12 +52,13 @@ impl system::Config for Test {
 	type BlockNumber = BlockNumber;
 	type BlockWeights = ();
 	type Call = Call;
+	type DataRootBuilderFilter = Test;
 	type DbWeight = ();
 	type Event = Event;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Header = Header<Self::BlockNumber, BlakeTwo256>;
-	type HeaderBuilder = frame_system::header_builder::da::HeaderBuilder<Test>;
+	type HeaderExtensionBuilder = frame_system::header_builder::da::HeaderExtensionBuilder<Test>;
 	type Index = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type OnKilledAccount = ();

--- a/pallets/nomad/da-bridge/src/tests.rs
+++ b/pallets/nomad/da-bridge/src/tests.rs
@@ -1,4 +1,4 @@
-use da_primitives::{Header, KateCommitment};
+use da_primitives::{Header, HeaderExtension};
 use frame_support::assert_ok;
 use frame_system::Config;
 use hex_literal::hex;
@@ -22,20 +22,19 @@ fn it_accepts_valid_extrinsic_root() {
 			fill_block_hash_mapping_up_to_n(9);
 
 			// Create extrinsics root for block 10
-			let extrinsics_root = KateCommitment {
-				hash: hex!("03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314")
-					.into(),
-				..Default::default()
-			};
+			let extension = HeaderExtension::default();
 
 			// Create block header for block 10
 			let header = Header::<<Test as Config>::BlockNumber, BlakeTwo256> {
 				parent_hash: [1u8; 32].into(),
 				number: 10 as u32,
 				state_root: [2u8; 32].into(),
-				extrinsics_root,
+				extrinsics_root: hex!(
+					"03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314"
+				)
+				.into(),
 				digest: Digest { logs: vec![] },
-				app_data_lookup: Default::default(),
+				extension,
 			};
 
 			// Insert 10th block's hash into block number --> hash mapping so

--- a/pallets/nomad/home/Cargo.toml
+++ b/pallets/nomad/home/Cargo.toml
@@ -14,10 +14,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # Our crates
-signature = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
-merkle = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
-nomad-base = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
-nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+signature = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+merkle = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+nomad-base = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
 updater-manager = { path = "../updater-manager", default-features = false }
 
 # 3rd-party
@@ -39,7 +39,7 @@ hex-literal = "0.3.4"
 
 [dev-dependencies]
 ethers-signers = "0.13.0"
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11" }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0" }
 test-case = "1.2.3"
 frame-benchmarking = "4.0.0-dev"
 

--- a/pallets/nomad/home/Cargo.toml
+++ b/pallets/nomad/home/Cargo.toml
@@ -14,10 +14,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # Our crates
-signature = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
-merkle = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
-nomad-base = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
-nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
+signature = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+merkle = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+nomad-base = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
 updater-manager = { path = "../updater-manager", default-features = false }
 
 # 3rd-party
@@ -39,7 +39,7 @@ hex-literal = "0.3.4"
 
 [dev-dependencies]
 ethers-signers = "0.13.0"
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1" }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11" }
 test-case = "1.2.3"
 frame-benchmarking = "4.0.0-dev"
 

--- a/pallets/nomad/home/Cargo.toml
+++ b/pallets/nomad/home/Cargo.toml
@@ -14,10 +14,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # Our crates
-signature = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
-merkle = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
-nomad-base = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
-nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+signature = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
+merkle = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
+nomad-base = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
+nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
 updater-manager = { path = "../updater-manager", default-features = false }
 
 # 3rd-party
@@ -39,7 +39,7 @@ hex-literal = "0.3.4"
 
 [dev-dependencies]
 ethers-signers = "0.13.0"
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0" }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1" }
 test-case = "1.2.3"
 frame-benchmarking = "4.0.0-dev"
 

--- a/pallets/nomad/home/src/mock.rs
+++ b/pallets/nomad/home/src/mock.rs
@@ -1,6 +1,6 @@
 use da_primitives::Header;
 use frame_support::{parameter_types, traits::GenesisBuild};
-use frame_system as system;
+use frame_system::{self as system, DRFCallOf, DRFOutput, DataRootFilter};
 use nomad_base::NomadBase;
 use primitive_types::{H160, H256};
 use sp_runtime::{
@@ -33,6 +33,12 @@ parameter_types! {
 	pub static ExistentialDeposit: u64 = 0;
 }
 
+impl DataRootFilter for Test {
+	type UncheckedExtrinsic = UncheckedExtrinsic;
+
+	fn filter(_call: &DRFCallOf<Self::UncheckedExtrinsic>) -> DRFOutput { None }
+}
+
 impl system::Config for Test {
 	type AccountData = ();
 	type AccountId = AccountId32;
@@ -42,12 +48,13 @@ impl system::Config for Test {
 	type BlockNumber = u32;
 	type BlockWeights = ();
 	type Call = Call;
+	type DataRootBuilderFilter = Test;
 	type DbWeight = ();
 	type Event = Event;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Header = Header<Self::BlockNumber, BlakeTwo256>;
-	type HeaderBuilder = frame_system::header_builder::da::HeaderBuilder<Test>;
+	type HeaderExtensionBuilder = frame_system::header_builder::da::HeaderExtensionBuilder<Test>;
 	type Index = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type OnKilledAccount = ();

--- a/pallets/nomad/updater-manager/Cargo.toml
+++ b/pallets/nomad/updater-manager/Cargo.toml
@@ -29,10 +29,10 @@ primitive-types = { git = "https://github.com/paritytech/parity-common.git", tag
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true }
 
 # Nomad
-nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
+nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
 
 [dev-dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1" }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11" }
 
 [features]
 default = ["std"]

--- a/pallets/nomad/updater-manager/Cargo.toml
+++ b/pallets/nomad/updater-manager/Cargo.toml
@@ -29,10 +29,10 @@ primitive-types = { git = "https://github.com/paritytech/parity-common.git", tag
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true }
 
 # Nomad
-nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
 
 [dev-dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0" }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1" }
 
 [features]
 default = ["std"]

--- a/pallets/nomad/updater-manager/Cargo.toml
+++ b/pallets/nomad/updater-manager/Cargo.toml
@@ -29,10 +29,10 @@ primitive-types = { git = "https://github.com/paritytech/parity-common.git", tag
 frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true }
 
 # Nomad
-nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+nomad-core = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
 
 [dev-dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11" }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0" }
 
 [features]
 default = ["std"]

--- a/pallets/nomad/updater-manager/src/mock.rs
+++ b/pallets/nomad/updater-manager/src/mock.rs
@@ -1,6 +1,6 @@
 use da_primitives::Header;
 use frame_support::parameter_types;
-use frame_system as system;
+use frame_system::{self as system, DRFCallOf, DRFOutput, DataRootFilter};
 use primitive_types::H256;
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 
@@ -28,6 +28,12 @@ parameter_types! {
 	pub static ExistentialDeposit: u64 = 0;
 }
 
+impl DataRootFilter for Test {
+	type UncheckedExtrinsic = UncheckedExtrinsic;
+
+	fn filter(_call: &DRFCallOf<Self::UncheckedExtrinsic>) -> DRFOutput { None }
+}
+
 impl system::Config for Test {
 	type AccountData = ();
 	type AccountId = u64;
@@ -37,12 +43,13 @@ impl system::Config for Test {
 	type BlockNumber = u32;
 	type BlockWeights = ();
 	type Call = Call;
+	type DataRootBuilderFilter = Test;
 	type DbWeight = ();
 	type Event = Event;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Header = Header<Self::BlockNumber, BlakeTwo256>;
-	type HeaderBuilder = frame_system::header_builder::da::HeaderBuilder<Test>;
+	type HeaderExtensionBuilder = frame_system::header_builder::da::HeaderExtensionBuilder<Test>;
 	type Index = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type OnKilledAccount = ();

--- a/pallets/system/Cargo.toml
+++ b/pallets/system/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false, features = ["header-backward-compatibility-test"] }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
 kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
 kate_v1 = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.1.0", package = "kate", default-features = false }
 da-primitives_v1 = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.1.0", package = "da-primitives", default-features = false }

--- a/pallets/system/Cargo.toml
+++ b/pallets/system/Cargo.toml
@@ -13,16 +13,13 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false, features = ["header-backward-compatibility-test"]}
 kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
-kate_v1 = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.1.0", package = "kate", default-features = false }
-da-primitives_v1 = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.1.0", package = "da-primitives", default-features = false }
-
 # Other
 impl-trait-for-tuples = "0.2.1"
 static_assertions = "1.1.0"
 log = { version = "0.4.14", default-features = false }
-rs_merkle = { version = "1.2.0", default-features = false }
+rs_merkle = { version = "1.2.0", default-features = false, optional = true }
 
 # Substrate
 serde = { version = "1.0.126", optional = true, features = ["derive"] }
@@ -35,6 +32,7 @@ sp-runtime = { version = "4.0.0-dev", default-features = false }
 sp-version = { version = "4.0.0-dev", default-features = false }
 frame-support = { version = "4.0.0-dev", default-features = false }
 sp-runtime-interface = { version = "4.0.0-dev", default-features = false }
+beefy-merkle-tree = { git = "https://github.com/paritytech/substrate.git/", branch = "polkadot-v0.9.13", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.3"
@@ -46,9 +44,7 @@ sp-externalities = "0.10.0-dev"
 default = ["std"]
 std = [
 	"kate/std",
-	"kate_v1/std",
 	"da-primitives/std",
-	"da-primitives_v1/std",
 	"serde",
 	"codec/std",
 	"scale-info/std",
@@ -59,6 +55,7 @@ std = [
 	"sp-runtime-interface/std",
 	"sp-runtime/std",
 	"sp-version/std",
+	"beefy-merkle-tree/std",
 	"log/std",
 ]
 runtime-benchmarks = [
@@ -66,6 +63,9 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 ]
 try-runtime = ["frame-support/try-runtime"]
+force-rs-merkle = [
+	"rs_merkle"
+]
 
 [[bench]]
 name = "bench"

--- a/pallets/system/Cargo.toml
+++ b/pallets/system/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false, features = ["header-backward-compatibility-test"]}
-kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false, features = ["header-backward-compatibility-test"]}
+kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
 # Other
 impl-trait-for-tuples = "0.2.1"
 static_assertions = "1.1.0"

--- a/pallets/system/Cargo.toml
+++ b/pallets/system/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false, features = ["header-backward-compatibility-test"] }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
 kate_v1 = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.1.0", package = "kate", default-features = false }
 da-primitives_v1 = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.1.0", package = "da-primitives", default-features = false }
 

--- a/pallets/system/Cargo.toml
+++ b/pallets/system/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false, features = ["header-backward-compatibility-test"]}
-kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false, features = ["header-backward-compatibility-test"]}
+kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
 # Other
 impl-trait-for-tuples = "0.2.1"
 static_assertions = "1.1.0"

--- a/pallets/system/benchmarking/Cargo.toml
+++ b/pallets/system/benchmarking/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-std = { version = "4.0.0-dev", default-features = false }

--- a/pallets/system/benchmarking/Cargo.toml
+++ b/pallets/system/benchmarking/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-std = { version = "4.0.0-dev", default-features = false }

--- a/pallets/system/benchmarking/Cargo.toml
+++ b/pallets/system/benchmarking/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 sp-std = { version = "4.0.0-dev", default-features = false }

--- a/pallets/system/benchmarking/src/lib.rs
+++ b/pallets/system/benchmarking/src/lib.rs
@@ -22,7 +22,7 @@
 use codec::Encode;
 use frame_benchmarking::{benchmarks, whitelisted_caller};
 use frame_support::{storage, traits::Get, weights::DispatchClass};
-use frame_system::{Call, Pallet as System, RawOrigin};
+use frame_system::{header_builder::HeaderExtensionBuilder, Call, Pallet as System, RawOrigin};
 use sp_core::storage::well_known_keys;
 use sp_runtime::traits::Hash;
 use sp_std::{prelude::*, vec};
@@ -122,6 +122,17 @@ benchmarks! {
 	}: _(RawOrigin::Root, prefix, p)
 	verify {
 		assert_eq!(storage::unhashed::get_raw(&last_key), None);
+	}
+
+	#[extra]
+	header_extension_builder {
+		let app_extrinsics = vec![];
+		let data_root = Default::default();
+		let block_length = Default::default();
+		let block_number = 1u32.into();
+
+	}: {
+		let _header = T::HeaderExtensionBuilder::build(app_extrinsics, data_root, block_length, block_number);
 	}
 
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);

--- a/pallets/system/benchmarking/src/mock.rs
+++ b/pallets/system/benchmarking/src/mock.rs
@@ -20,7 +20,7 @@
 #![cfg(test)]
 
 use da_primitives::Header;
-use frame_system::tests::TestRandomness;
+use frame_system::{tests::TestRandomness, DRFCallOf, DRFOutput, DataRootFilter};
 use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 
 type AccountId = u64;
@@ -40,6 +40,12 @@ frame_support::construct_runtime!(
 	}
 );
 
+impl DataRootFilter for Test {
+	type UncheckedExtrinsic = UncheckedExtrinsic;
+
+	fn filter(_call: &DRFCallOf<Self::UncheckedExtrinsic>) -> DRFOutput { None }
+}
+
 impl frame_system::Config for Test {
 	type AccountData = ();
 	type AccountId = AccountId;
@@ -49,12 +55,13 @@ impl frame_system::Config for Test {
 	type BlockNumber = BlockNumber;
 	type BlockWeights = ();
 	type Call = Call;
+	type DataRootBuilderFilter = Test;
 	type DbWeight = ();
 	type Event = Event;
 	type Hash = sp_core::H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type Header = Header<BlockNumber, BlakeTwo256>;
-	type HeaderBuilder = frame_system::header_builder::da::HeaderBuilder<Test>;
+	type HeaderExtensionBuilder = frame_system::header_builder::da::HeaderExtensionBuilder<Test>;
 	type Index = AccountIndex;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type OnKilledAccount = ();

--- a/pallets/system/src/data_root_builder.rs
+++ b/pallets/system/src/data_root_builder.rs
@@ -1,0 +1,355 @@
+use codec::Decode;
+use da_primitives::asdr::AppExtrinsic;
+use frame_support::traits::ExtrinsicCall;
+use sp_core::H256;
+use sp_runtime::traits::Extrinsic;
+use sp_std::vec::Vec;
+
+const LOG_TARGET: &str = "runtime::system::data_root_builder";
+
+pub type DRFOutput = Option<Vec<u8>>;
+pub type DRFCallOf<T> = <T as Extrinsic>::Call;
+
+pub trait DataRootFilter {
+	type UncheckedExtrinsic: Decode + ExtrinsicCall;
+
+	fn filter(call: &DRFCallOf<Self::UncheckedExtrinsic>) -> DRFOutput;
+}
+
+pub trait DataRootBuilder<F: DataRootFilter> {
+	fn build<'a, I>(app_extrinsics: I) -> H256
+	where
+		I: IntoIterator<Item = &'a AppExtrinsic>,
+	{
+		let mut used_extrinsics_count = 0u32;
+		let mut total_extrinsics_count = 0u32;
+
+		let filtered_iter = app_extrinsics
+			.into_iter()
+			.enumerate()
+			.filter_map(|(idx, app_extrinsic)| {
+				// Decode call and log any failure.
+				total_extrinsics_count += 1;
+				match F::UncheckedExtrinsic::decode(&mut app_extrinsic.data.as_slice()) {
+					Ok(app_unchecked_extrinsic) => {
+						// Some((app_unchecked_extrinsic, app_extrinsic.data.as_slice()))
+						Some(app_unchecked_extrinsic)
+					},
+					Err(err) => {
+						log::error!(
+							target: LOG_TARGET,
+							"Extrinsic {} cannot be decoded: {:?}",
+							idx,
+							err
+						);
+						None
+					},
+				}
+			})
+			.filter_map(|app_unchecked_extrinsic| {
+				// Filter calls and traces removed calls
+				// @TODO: We could avoid the the copy of data from filter
+				// once `beefy_merkle_tree::merkelize` becomes public. In that case,
+				// we could work with iterator and lifescopes, having something like:
+				//
+				// ```Rust
+				// pub trait DataRootFilter {
+				//	type UncheckedExtrinsic: Decode + ExtrinsicCall;
+				//	fn filter<'a>(call: &'a <Self::UncheckedExtrinsic as Extrinsic>::Call) -> Option<&'a [u8]>;
+				//	}
+				// ```
+				let maybe_data = F::filter(app_unchecked_extrinsic.call());
+				if maybe_data.is_some() {
+					used_extrinsics_count += 1;
+				}
+
+				maybe_data
+			});
+
+		let root = Self::merkle_root(filtered_iter);
+
+		log::debug!(
+			target: LOG_TARGET,
+			"Used {} extrinsics of {}",
+			used_extrinsics_count,
+			total_extrinsics_count
+		);
+
+		root.into()
+	}
+
+	#[cfg(not(feature = "force-rs-merkle"))]
+	fn merkle_root<I>(leaves: I) -> H256
+	where
+		I: Iterator<Item = Vec<u8>>,
+	{
+		use beefy_merkle_tree::{merkle_root, Hash, Hasher};
+		use sp_io::hashing::sha2_256;
+
+		#[derive(Copy, Clone)]
+		struct Sha2_256 {}
+
+		impl Hasher for Sha2_256 {
+			fn hash(data: &[u8]) -> Hash { sha2_256(data) }
+		}
+
+		merkle_root::<Sha2_256, _, _>(leaves).into()
+	}
+
+	#[cfg(feature = "force-rs-merkle")]
+	fn merkle_root<'a, I>(leaves: I) -> H256
+	where
+		I: Iterator<Item = Vec<u8>>,
+	{
+		use rs_merkle::{algorithms::Sha256, Hasher, MerkleTree};
+
+		let mut tree = MerkleTree::<Sha256>::new();
+		leaves.for_each(|leave| {
+			let leave_hash = Sha256::hash(leave.as_slice());
+			tree.insert(leave_hash);
+		});
+
+		tree.commit();
+		tree.root().unwrap_or_default().into()
+	}
+}
+
+impl<F: DataRootFilter> DataRootBuilder<F> for F {}
+
+#[cfg(all(test, feature = "force-rs-merkle"))]
+mod test {
+	use da_primitives::asdr::AppId;
+	use hex_literal::hex;
+	use rs_merkle::{algorithms::Sha256, Hasher, MerkleTree};
+	use test_case::test_case;
+
+	use super::*;
+
+	mod nomad {
+		use codec::{Compact, Error as DecodeError, Input};
+		use sp_runtime::{AccountId32, MultiAddress, MultiSignature};
+
+		use super::*;
+
+		#[derive(Debug, Clone, PartialEq, Eq, Default)]
+		pub struct AvailExtrinsic {
+			pub app_id: u32,
+			pub signature: Option<MultiSignature>,
+			pub data: Vec<u8>,
+		}
+
+		pub type AvailSignedExtra = ((), (), (), AvailMortality, Nonce, (), Balance, u32);
+
+		#[derive(Decode)]
+		pub struct Balance(#[codec(compact)] u128);
+
+		#[derive(Decode)]
+		pub struct Nonce(#[codec(compact)] u32);
+
+		pub enum AvailMortality {
+			Immortal,
+			Mortal(u64, u64),
+		}
+
+		impl Decode for AvailMortality {
+			fn decode<I: Input>(input: &mut I) -> Result<Self, DecodeError> {
+				let first = input.read_byte()?;
+				if first == 0 {
+					Ok(Self::Immortal)
+				} else {
+					let encoded = first as u64 + ((input.read_byte()? as u64) << 8);
+					let period = 2 << (encoded % (1 << 4));
+					let quantize_factor = (period >> 12).max(1);
+					let phase = (encoded >> 4) * quantize_factor;
+					if period >= 4 && phase < period {
+						Ok(Self::Mortal(period, phase))
+					} else {
+						Err("Invalid period and phase".into())
+					}
+				}
+			}
+		}
+
+		const EXTRINSIC_VERSION: u8 = 4;
+		impl Decode for AvailExtrinsic {
+			fn decode<I: Input>(input: &mut I) -> Result<AvailExtrinsic, DecodeError> {
+				// This is a little more complicated than usual since the binary format must be compatible
+				// with substrate's generic `Vec<u8>` type. Basically this just means accepting that there
+				// will be a prefix of vector length (we don't need
+				// to use this).
+				let _length_do_not_remove_me_see_above: Compact<u32> = Decode::decode(input)?;
+
+				let version = input.read_byte()?;
+
+				let is_signed = version & 0b1000_0000 != 0;
+				let version = version & 0b0111_1111;
+				if version != EXTRINSIC_VERSION {
+					return Err("Invalid transaction version".into());
+				}
+				let (app_id, signature) = if is_signed {
+					let _address = <MultiAddress<AccountId32, u32>>::decode(input)?;
+					let sig = MultiSignature::decode(input)?;
+					let extra = <AvailSignedExtra>::decode(input)?;
+					let app_id = extra.7;
+
+					(app_id, Some(sig))
+				} else {
+					return Err("Not signed".into());
+				};
+
+				let section: u8 = Decode::decode(input)?;
+				let method: u8 = Decode::decode(input)?;
+
+				let data: Vec<u8> = match (section, method) {
+					// TODO: Define these pairs as enums or better yet - make a dependency on substrate enums if possible
+					(29, 1) => Decode::decode(input)?,
+					_ => return Err("Not Avail Extrinsic".into()),
+				};
+
+				Ok(Self {
+					app_id,
+					signature,
+					data,
+				})
+			}
+		}
+	}
+
+	fn encoded_timestamp_call() -> AppExtrinsic {
+		AppExtrinsic {
+			app_id: 0.into(),
+			data: hex!("280403000BC26208378301").into(),
+		}
+	}
+
+	fn encoded_fillblock_call<A: Into<AppId>>(app_id: A) -> AppExtrinsic {
+		let data = hex!("5D0284001CBD2D43530A44705AD088AF313E18F80B53EF16B36177CD4B77B846F2A5F07C01C44755794EA949E9410390CB4CE07FE2D8068656185B5AB9B43EEF934C3680478968C1F83E360A5D942FE75E9D58E49106A8E8B23601CBC6A633D80E5D089D83A4000400030000001D01A46868616A6B616E636B61206C61682069616B6A206361697568206162206169616A6820612067616861").to_vec();
+		AppExtrinsic {
+			app_id: app_id.into(),
+			data,
+		}
+	}
+
+	fn encoded_tx_bob() -> AppExtrinsic {
+		let data = hex!("490284001cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c0166de9fcb3903fa119cb6d23dd903b93a67719f76922b2b4c15a2539d11021102b75f4c452595b65b3bacef0e852430bbfa44bd38133b16cd5d48edb45962568204010000000000000600008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a4802093d00").to_vec();
+		AppExtrinsic {
+			app_id: 0.into(),
+			data,
+		}
+	}
+
+	fn dr_input_1() -> Vec<AppExtrinsic> {
+		vec![encoded_timestamp_call(), encoded_fillblock_call(3)]
+	}
+
+	fn dr_output_1() -> H256 {
+		hex!("DDF368647A902A6F6AB9F53B32245BE28EDC99E92F43F0004BBC2CB359814B2A").into()
+	}
+
+	/*
+	#[test_case( dr_input_1() => dr_output_1())]
+	#[test_case( vec![encoded_timestamp_call()] => H256::zero(); "Empty block")]
+	#[test_case( vec![encoded_tx_bob()] => H256::zero(); "Signed Native Tx")]
+	fn it_build_data_root(app_extrinsics: Vec<AppExtrinsic>) -> H256 {
+		build_data_root(&app_extrinsics)
+	}*/
+
+	#[test]
+	fn test_merkle_proof() {
+		let avail_data: Vec<Vec<u8>> = vec![
+			hex!("3033333166613733656565636362653465323235").into(),
+			hex!("3630646564316635616236373261373132376261").into(),
+			hex!("3262313166316464333935353666623261623432").into(),
+		];
+
+		let leaves = avail_data
+			.iter()
+			.map(|xt| Sha256::hash(&xt))
+			.collect::<Vec<[u8; 32]>>();
+
+		let data_tree = MerkleTree::<Sha256>::from_leaves(&leaves);
+		let proof = data_tree.proof(&[1usize]);
+		let root_proof = proof.proof_hashes().to_vec();
+		assert_eq!(root_proof, vec![
+			hex!("754B9412E0ED7907BDF4B7CA5D2A22F5E129A03DEB1F4E1C1FE42D322FDEE90E"),
+			hex!("8D6E30E494D17D7675A94C3C614467FF8CCE35201C1056751A6E9A100515DAF9")
+		]);
+	}
+
+	#[test]
+	fn test_single_merkle_proof() {
+		let empty_vec: Vec<[u8; 32]> = vec![];
+
+		let avail_data: Vec<Vec<u8>> =
+			vec![hex!("3435346666383063303838616137666162396531").to_vec()];
+
+		let leaves = avail_data
+			.iter()
+			.map(|xt| Sha256::hash(&xt))
+			.collect::<Vec<[u8; 32]>>();
+
+		let data_tree = MerkleTree::<Sha256>::from_leaves(&leaves);
+		let proof = data_tree.proof(&[0usize]);
+		let root_proof = proof.proof_hashes().to_vec();
+		// here the proof is shown empty because the root itself is the proof as there is only one appdata extrinsic
+		assert_eq!(root_proof, empty_vec);
+	}
+
+	///using rs-merkle proof verify function
+	#[test]
+	fn verify_merkle_proof() {
+		let avail_data: Vec<Vec<u8>> = vec![
+			hex!("3033333166613733656565636362653465323235").into(),
+			hex!("3630646564316635616236373261373132376261").into(),
+			hex!("3262313166316464333935353666623261623432").into(),
+			hex!("6433326630643762346634306264346563323665").into(),
+		];
+		let leaves = avail_data
+			.iter()
+			.map(|xt| Sha256::hash(&xt))
+			.collect::<Vec<[u8; 32]>>();
+
+		let merkle_tree = MerkleTree::<Sha256>::from_leaves(&leaves);
+		let indices_to_prove = vec![3];
+		let leaves_to_prove = leaves.get(3..4).ok_or("can't get leaves to prove").unwrap();
+
+		let proof = merkle_tree.proof(&indices_to_prove);
+		let root = merkle_tree
+			.root()
+			.ok_or("couldn't get the merkle root")
+			.unwrap();
+
+		assert!(proof.verify(root, &indices_to_prove, leaves_to_prove, leaves.len()));
+	}
+
+	#[test]
+	fn verify_nodata_merkle_proof() {
+		let avail_data: Vec<Vec<u8>> = vec![];
+
+		let leaves = avail_data
+			.iter()
+			.map(|xt| Sha256::hash(&xt))
+			.collect::<Vec<[u8; 32]>>();
+		let leaves_to_prove = if let Ok(leaves) = leaves.get(0).ok_or("can't get leaves to prove") {
+			leaves
+		} else {
+			&[0u8; 32]
+		};
+		assert_eq!(leaves_to_prove, &[0u8; 32]);
+	}
+
+	fn encoded_submit_call<A: Into<AppId>>(app_id: A) -> AppExtrinsic {
+		let data = hex!("5D0284001CBD2D43530A44705AD088AF313E18F80B53EF16B36177CD4B77B846F2A5F07C01C44755794EA949E9410390CB4CE07FE2D8068656185B5AB9B43EEF934C3680478968C1F83E360A5D942FE75E9D58E49106A8E8B23601CBC6A633D80E5D089D83A4000400030000001D01A46868616A6B616E636B61206C61682069616B6A206361697568206162206169616A6820612067616861").to_vec();
+		AppExtrinsic {
+			app_id: app_id.into(),
+			data,
+		}
+	}
+
+	/*
+	#[test_case( encoded_submit_call(0) => H256(hex!("ddf368647a902a6f6ab9f53b32245be28edc99e92f43f0004bbc2cb359814b2a")); "Submit data 0")]
+	#[test_case( encoded_submit_call(1) => H256(hex!("ddf368647a902a6f6ab9f53b32245be28edc99e92f43f0004bbc2cb359814b2a")); "Submit data 1")]
+	fn nomad_merkle_root_compatibility(extrinsic: AppExtrinsic) -> H256 {
+		build_data_root(&[extrinsic])
+	}*/
+}

--- a/pallets/system/src/data_root_builder.rs
+++ b/pallets/system/src/data_root_builder.rs
@@ -31,11 +31,12 @@ pub trait DataRootBuilder<F: DataRootFilter> {
 				// Decode call and log any failure.
 				total_extrinsics_count += 1;
 				match F::UncheckedExtrinsic::decode(&mut app_extrinsic.data.as_slice()) {
-					Ok(app_unchecked_extrinsic) => {
-						// Some((app_unchecked_extrinsic, app_extrinsic.data.as_slice()))
-						Some(app_unchecked_extrinsic)
-					},
+					Ok(app_unchecked_extrinsic) => Some(app_unchecked_extrinsic),
 					Err(err) => {
+						// NOTE: Decodification issue is like a `unrecheable` because this
+						// extrinsic was decoded previously, when node executed the block.
+						// We will keep this here just to have a trace if we update
+						// `System::note_extrinsic` in the future.
 						log::error!(
 							target: LOG_TARGET,
 							"Extrinsic {} cannot be decoded: {:?}",

--- a/pallets/system/src/header_builder.rs
+++ b/pallets/system/src/header_builder.rs
@@ -1,19 +1,16 @@
-use codec::{Compact, Decode, Encode, Error as DecodeError, Input};
-use da_primitives::{
-	asdr::{AppExtrinsic, DataLookup},
-	traits::ExtendedHeader,
-	HeaderExtension, KateCommitment,
-};
-use frame_support::{ensure, traits::Randomness};
+use da_primitives::{asdr::AppExtrinsic, traits::ExtendedHeader, HeaderExtension};
+#[cfg(feature = "std")]
+use da_primitives::{asdr::DataLookup, KateCommitment};
+use frame_support::traits::Randomness;
 pub use kate::Seed;
-use rs_merkle::{algorithms::Sha256, Hasher, MerkleTree};
-use scale_info::TypeInfo;
 use sp_core::H256;
-use sp_runtime::{traits::Hash, AccountId32, MultiAddress, MultiSignature, SaturatedConversion};
-use sp_runtime_interface::{pass_by::PassByCodec, runtime_interface};
+use sp_runtime::traits::Hash;
+#[cfg(feature = "std")]
+use sp_runtime::SaturatedConversion;
+use sp_runtime_interface::runtime_interface;
 use sp_std::vec::Vec;
 
-use crate::{generic::Digest, limits::BlockLength, Config, LOG_TARGET};
+use crate::{limits::BlockLength, Config, LOG_TARGET};
 
 pub mod da {
 	use core::marker::PhantomData;
@@ -21,33 +18,28 @@ pub mod da {
 	use da_primitives::Header as DaHeader;
 	use sp_runtime::traits::BlakeTwo256;
 
-	use super::{AppExtrinsic, BlockLength, Config, DigestWrapper, Vec};
-
-	pub type BlockNumber = u32;
+	use super::{AppExtrinsic, BlockLength, Config, HeaderExtension, Vec, H256};
 	pub type Hash = sp_core::H256;
-	pub type Hasher = BlakeTwo256;
-	pub type Header = DaHeader<BlockNumber, Hasher>;
+	pub type BlockNumber = u32;
 
 	/// Data-Avail Header builder.
-	pub struct HeaderBuilder<T: Config>(PhantomData<T>);
+	pub struct HeaderExtensionBuilder<T: Config>(PhantomData<T>);
 
-	impl<T: Config> super::HeaderBuilder for HeaderBuilder<T> {
-		type Header = Header;
+	impl<T: Config> super::HeaderExtensionBuilder for HeaderExtensionBuilder<T> {
+		type Header = DaHeader<BlockNumber, BlakeTwo256>;
 
 		#[inline]
 		fn build(
 			app_extrinsics: Vec<AppExtrinsic>,
-			parent_hash: Hash,
-			digest: DigestWrapper,
+			data_root: H256,
 			block_length: BlockLength,
 			block_number: BlockNumber,
-		) -> Header {
+		) -> HeaderExtension {
 			let seed = Self::random_seed::<T>();
 
 			super::hosted_header_builder::build(
 				app_extrinsics,
-				parent_hash,
-				digest,
+				data_root,
 				block_length,
 				block_number,
 				seed,
@@ -56,26 +48,17 @@ pub mod da {
 	}
 }
 
-/// It is just a wapper to support `PassBy` on `Digest` type.
-#[derive(Clone, TypeInfo, Encode, Decode, PassByCodec)]
-pub struct DigestWrapper(pub Digest);
-
-impl From<Digest> for DigestWrapper {
-	fn from(d: Digest) -> Self { Self(d) }
-}
-
 /// Trait for header builder.
-pub trait HeaderBuilder {
+pub trait HeaderExtensionBuilder {
 	type Header: sp_runtime::traits::Header + ExtendedHeader;
 
 	/// Creates the header using the given parameters.
 	fn build(
 		app_extrinsics: Vec<AppExtrinsic>,
-		parent_hash: <Self::Header as sp_runtime::traits::Header>::Hash,
-		digest: DigestWrapper,
+		data_root: H256,
 		block_length: BlockLength,
 		block_number: <Self::Header as sp_runtime::traits::Header>::Number,
-	) -> Self::Header;
+	) -> HeaderExtension;
 
 	/// Generates a random seed using the _epoch seed_ and the _current block_ returned by
 	/// `T::Randomness` type.
@@ -95,59 +78,15 @@ pub trait HeaderBuilder {
 	}
 }
 
-fn build_base(
-	app_extrinsics: &[AppExtrinsic],
-	parent_hash: da::Hash,
-	digest: DigestWrapper,
-	block_length: BlockLength,
-	block_number: da::BlockNumber,
-	seed: Seed,
-	build_extension: fn(&[AppExtrinsic], BlockLength, Seed) -> HeaderExtension,
-) -> da::Header {
-	use sp_io::storage::{changes_root, root};
-
-	use crate::generic::DigestItem;
-
-	let extension = build_extension(app_extrinsics, block_length, seed);
-
-	// @TODO Miguel: Is it possible to avoid copies here?
-	let extrinsics = app_extrinsics
-		.iter()
-		.map(|e| e.data.clone())
-		.collect::<Vec<_>>();
-	let extrinsics_root = da::Hasher::ordered_trie_root(extrinsics);
-
-	let mut digest = digest.0;
-	let storage_root =
-		da::Hash::decode(&mut &root()[..]).expect("Node is configured to use the same hash; qed");
-
-	// we can't compute changes trie root earlier && put it to the Digest
-	// because it will include all currently existing temporaries.
-	if let Some(storage_changes_root) = changes_root(&parent_hash.encode()) {
-		let hash_changes_root = da::Hash::decode(&mut &storage_changes_root[..])
-			.expect("Node is configured to use the same hash; qed");
-		let item = DigestItem::Other(hash_changes_root.as_ref().to_vec());
-		digest.push(item);
-	}
-
-	<da::Header as ExtendedHeader>::new(
-		block_number,
-		extrinsics_root,
-		storage_root,
-		parent_hash,
-		digest,
-		extension,
-	)
-}
-
-/// Builds commitments using `Plonk v0.8.9`
-#[cfg(all(feature = "std", feature = "header-backward-compatibility-test"))]
+#[allow(dead_code)]
+#[cfg(feature = "std")]
 fn build_extension_v_test(
 	app_extrinsics: &[AppExtrinsic],
+	data_root: H256,
 	block_length: BlockLength,
 	seed: Seed,
 ) -> HeaderExtension {
-	let extension_v1 = build_extension_v1(app_extrinsics, block_length, seed);
+	let extension_v1 = build_extension_v1(app_extrinsics, data_root, block_length, seed);
 	match extension_v1 {
 		HeaderExtension::V1(extension) => HeaderExtension::VTest(extension.into()),
 		r @ HeaderExtension::VTest(_) => r,
@@ -157,6 +96,7 @@ fn build_extension_v_test(
 #[cfg(feature = "std")]
 fn build_extension_v1(
 	app_extrinsics: &[AppExtrinsic],
+	data_root: H256,
 	block_length: BlockLength,
 	seed: Seed,
 ) -> HeaderExtension {
@@ -172,14 +112,6 @@ fn build_extension_v1(
 	.expect("Build commitments cannot fail .qed");
 	let app_lookup =
 		DataLookup::try_from(xts_layout.as_slice()).expect("Extrinsic size cannot overflow .qed");
-	let data_root = build_data_root(app_extrinsics);
-
-	log::debug!(
-		target: LOG_TARGET,
-		"Build Commitment (v1): Data Root: {:?}, App Lookup : {:?}",
-		data_root,
-		app_lookup
-	);
 
 	let commitment = KateCommitment {
 		rows: block_dims.rows.saturated_into::<u16>(),
@@ -202,303 +134,33 @@ pub trait HostedHeaderBuilder {
 	#[version(1)]
 	fn build(
 		app_extrinsics: Vec<AppExtrinsic>,
-		parent_hash: da::Hash,
-		digest: DigestWrapper,
+		data_root: H256,
 		block_length: BlockLength,
-		block_number: da::BlockNumber,
+		_block_number: u32,
 		seed: Seed,
-	) -> da::Header {
-		build_base(
-			app_extrinsics.as_slice(),
-			parent_hash,
-			digest,
-			block_length,
-			block_number,
-			seed,
-			build_extension_v1,
-		)
+	) -> HeaderExtension {
+		build_extension_v1(&app_extrinsics, data_root, block_length, seed)
 	}
 
+	// @TODO Miguel: Substrate v0.9.29 supports deactivated new version of hosted functions.
+	// NOTE: It is just for testing the forward compatibility in header extension.
 	/*
 	#[version(2)]
 	fn build(
 		app_extrinsics: Vec<AppExtrinsic>,
-		parent_hash: da::Hash,
-		digest: DigestWrapper,
+		data_root: H256,
 		block_length: BlockLength,
-		block_number: da::BlockNumber,
+		block_number: u32,
 		seed: Seed,
-	) -> da::Header {
-		build_base(
-			app_extrinsics.as_slice(),
-			parent_hash,
-			digest,
-			block_length,
-			block_number,
-			seed,
-			build_extension_v_test,
-		)
-	}*/
-}
-
-/*
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct AvailExtrinsic {
-	pub app_id: u32,
-	pub signature: Option<MultiSignature>,
-	pub data: Vec<u8>,
-}
-*/
-
-pub type AvailSignedExtra = ((), (), (), AvailMortality, Nonce, (), Balance, u32);
-
-#[derive(Decode)]
-pub struct Balance(#[codec(compact)] u128);
-
-#[derive(Decode)]
-pub struct Nonce(#[codec(compact)] u32);
-
-pub enum AvailMortality {
-	Immortal,
-	Mortal(u64, u64),
-}
-
-impl Decode for AvailMortality {
-	fn decode<I: Input>(input: &mut I) -> Result<Self, DecodeError> {
-		let first = input.read_byte()?;
-		if first == 0 {
-			Ok(Self::Immortal)
+	) -> HeaderExtension {
+		// Genesis HAS TO use the legacy header extension
+		let build_extension_fn = if block_number > 1 {
+			build_extension_v_test
 		} else {
-			let encoded = first as u64 + ((input.read_byte()? as u64) << 8);
-			let period = 2 << (encoded % (1 << 4));
-			let quantize_factor = (period >> 12).max(1);
-			let phase = (encoded >> 4) * quantize_factor;
-			if period >= 4 && phase < period {
-				Ok(Self::Mortal(period, phase))
-			} else {
-				Err("Invalid period and phase".into())
-			}
-		}
-	}
-}
-
-/*
-impl Decode for AvailExtrinsic {
-	fn decode<I: Input>(input: &mut I) -> Result<AvailExtrinsic, DecodeError> {
-		// This is a little more complicated than usual since the binary format must be compatible
-		// with substrate's generic `Vec<u8>` type. Basically this just means accepting that there
-		// will be a prefix of vector length (we don't need
-		// to use this).
-		let _length_do_not_remove_me_see_above: Compact<u32> = Decode::decode(input)?;
-
-		let version = input.read_byte()?;
-
-		let is_signed = version & 0b1000_0000 != 0;
-		let version = version & 0b0111_1111;
-		if version != EXTRINSIC_VERSION {
-			return Err("Invalid transaction version".into());
-		}
-		let (app_id, signature) = if is_signed {
-			let _address = <MultiAddress<AccountId32, u32>>::decode(input)?;
-			let sig = MultiSignature::decode(input)?;
-			let extra = <AvailSignedExtra>::decode(input)?;
-			let app_id = extra.7;
-
-			(app_id, Some(sig))
-		} else {
-			return Err("Not signed".into());
+			build_extension_v1
 		};
 
-		let section: u8 = Decode::decode(input)?;
-		let method: u8 = Decode::decode(input)?;
-
-		let data: Vec<u8> = match (section, method) {
-			// TODO: Define these pairs as enums or better yet - make a dependency on substrate enums if possible
-			(29, 1) => Decode::decode(input)?,
-			_ => return Err("Not Avail Extrinsic".into()),
-		};
-
-		Ok(Self {
-			app_id,
-			signature,
-			data,
-		})
+		build_extension_fn(app_extrinsics.as_slice(), data_root, block_length, seed)
 	}
-}*/
-
-fn filter_map_submit_data(input: &mut &[u8]) -> Result<<Sha256 as Hasher>::Hash, DecodeError> {
-	const EXTRINSIC_VERSION: u8 = 4;
-
-	// This is a little more complicated than usual since the binary format must be compatible
-	// with substrate's generic `Vec<u8>` type. Basically this just means accepting that there
-	// will be a prefix of vector length (we don't need
-	// to use this).
-	let _length_do_not_remove_me_see_above: Compact<u32> = Decode::decode(input)?;
-
-	let version = input.read_byte()?;
-	let is_signed = version & 0b1000_0000 != 0;
-	ensure!(is_signed, "Not signed");
-
-	let version = version & 0b0111_1111;
-	ensure!(version == EXTRINSIC_VERSION, "Invalid transaction version");
-
-	let _address = <MultiAddress<AccountId32, u32>>::decode(input)?;
-	let _signature = MultiSignature::decode(input)?;
-	let _extra = <AvailSignedExtra>::decode(input)?;
-
-	let pallet: u8 = Decode::decode(input)?;
-	let method: u8 = Decode::decode(input)?;
-	ensure!(pallet == 29 && method == 1, "Not DaCtrl::submit_data");
-
-	let data_size = Compact::<u32>::decode(input)?.0 as usize;
-	ensure!(input.len() >= data_size, "Corrupted extrinsic");
-	Ok(Sha256::hash(&input[..data_size]))
-}
-
-fn build_data_root(app_ext: &[AppExtrinsic]) -> H256 {
-	let mut tree = MerkleTree::<Sha256>::new();
-
-	app_ext
-		.iter()
-		// NOTE: `AvailExtrinsic` decode fn will filter onlye `Da_Control::submit_data` extrinsics.
-		// TODO: It implies a circular dependency atm between system & DA control pallets.
-		.filter_map(|e| filter_map_submit_data(&mut e.data.as_slice()).ok())
-		.for_each(|hash| {
-			tree.insert(hash);
-		});
-
-	tree.commit();
-	tree.root().unwrap_or_default().into()
-}
-
-#[cfg(test)]
-mod tests {
-	use da_primitives::asdr::AppId;
-	use hex_literal::hex;
-	use sp_core::H256;
-	use test_case::test_case;
-
-	use super::*;
-
-	fn encoded_timestamp_call() -> AppExtrinsic {
-		AppExtrinsic {
-			app_id: 0.into(),
-			data: hex!("280403000BC26208378301").into(),
-		}
-	}
-
-	fn encoded_fillblock_call<A: Into<AppId>>(app_id: A) -> AppExtrinsic {
-		let data = hex!("5D0284001CBD2D43530A44705AD088AF313E18F80B53EF16B36177CD4B77B846F2A5F07C01C44755794EA949E9410390CB4CE07FE2D8068656185B5AB9B43EEF934C3680478968C1F83E360A5D942FE75E9D58E49106A8E8B23601CBC6A633D80E5D089D83A4000400030000001D01A46868616A6B616E636B61206C61682069616B6A206361697568206162206169616A6820612067616861").to_vec();
-		AppExtrinsic {
-			app_id: app_id.into(),
-			data,
-		}
-	}
-
-	fn encoded_tx_bob() -> AppExtrinsic {
-		let data = hex!("490284001cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c0166de9fcb3903fa119cb6d23dd903b93a67719f76922b2b4c15a2539d11021102b75f4c452595b65b3bacef0e852430bbfa44bd38133b16cd5d48edb45962568204010000000000000600008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a4802093d00").to_vec();
-		AppExtrinsic {
-			app_id: 0.into(),
-			data,
-		}
-	}
-
-	fn dr_input_1() -> Vec<AppExtrinsic> {
-		vec![encoded_timestamp_call(), encoded_fillblock_call(3)]
-	}
-
-	fn dr_output_1() -> H256 {
-		hex!("DDF368647A902A6F6AB9F53B32245BE28EDC99E92F43F0004BBC2CB359814B2A").into()
-	}
-
-	#[test_case( dr_input_1() => dr_output_1())]
-	#[test_case( vec![encoded_timestamp_call()] => H256::zero(); "Empty block")]
-	#[test_case( vec![encoded_tx_bob()] => H256::zero(); "Signed Native Tx")]
-	fn it_build_data_root(app_extrinsics: Vec<AppExtrinsic>) -> H256 {
-		build_data_root(&app_extrinsics).into()
-	}
-
-	#[test]
-	fn test_merkle_proof() {
-		let avail_data: Vec<Vec<u8>> = vec![
-			hex!("3033333166613733656565636362653465323235").into(),
-			hex!("3630646564316635616236373261373132376261").into(),
-			hex!("3262313166316464333935353666623261623432").into(),
-		];
-
-		let leaves = avail_data
-			.iter()
-			.map(|xt| Sha256::hash(&xt))
-			.collect::<Vec<[u8; 32]>>();
-
-		let data_tree = MerkleTree::<Sha256>::from_leaves(&leaves);
-		let proof = data_tree.proof(&[1usize]);
-		let root_proof = proof.proof_hashes().to_vec();
-		assert_eq!(root_proof, vec![
-			hex!("754B9412E0ED7907BDF4B7CA5D2A22F5E129A03DEB1F4E1C1FE42D322FDEE90E"),
-			hex!("8D6E30E494D17D7675A94C3C614467FF8CCE35201C1056751A6E9A100515DAF9")
-		]);
-	}
-
-	#[test]
-	fn test_single_merkle_proof() {
-		let empty_vec: Vec<[u8; 32]> = vec![];
-
-		let avail_data: Vec<Vec<u8>> =
-			vec![hex!("3435346666383063303838616137666162396531").to_vec()];
-
-		let leaves = avail_data
-			.iter()
-			.map(|xt| Sha256::hash(&xt))
-			.collect::<Vec<[u8; 32]>>();
-
-		let data_tree = MerkleTree::<Sha256>::from_leaves(&leaves);
-		let proof = data_tree.proof(&[0usize]);
-		let root_proof = proof.proof_hashes().to_vec();
-		// here the proof is shown empty because the root itself is the proof as there is only one appdata extrinsic
-		assert_eq!(root_proof, empty_vec);
-	}
-
-	///using rs-merkle proof verify function
-	#[test]
-	fn verify_merkle_proof() {
-		let avail_data: Vec<Vec<u8>> = vec![
-			hex!("3033333166613733656565636362653465323235").into(),
-			hex!("3630646564316635616236373261373132376261").into(),
-			hex!("3262313166316464333935353666623261623432").into(),
-			hex!("6433326630643762346634306264346563323665").into(),
-		];
-		let leaves = avail_data
-			.iter()
-			.map(|xt| Sha256::hash(&xt))
-			.collect::<Vec<[u8; 32]>>();
-
-		let merkle_tree = MerkleTree::<Sha256>::from_leaves(&leaves);
-		let indices_to_prove = vec![3];
-		let leaves_to_prove = leaves.get(3..4).ok_or("can't get leaves to prove").unwrap();
-
-		let proof = merkle_tree.proof(&indices_to_prove);
-		let root = merkle_tree
-			.root()
-			.ok_or("couldn't get the merkle root")
-			.unwrap();
-
-		assert!(proof.verify(root, &indices_to_prove, leaves_to_prove, leaves.len()));
-	}
-
-	#[test]
-	fn verify_nodata_merkle_proof() {
-		let avail_data: Vec<Vec<u8>> = vec![];
-
-		let leaves = avail_data
-			.iter()
-			.map(|xt| Sha256::hash(&xt))
-			.collect::<Vec<[u8; 32]>>();
-		let leaves_to_prove = if let Ok(leaves) = leaves.get(0).ok_or("can't get leaves to prove") {
-			leaves
-		} else {
-			&[0u8; 32]
-		};
-		assert_eq!(leaves_to_prove, &[0u8; 32]);
-	}
+	*/
 }

--- a/pallets/system/src/lib.rs
+++ b/pallets/system/src/lib.rs
@@ -64,7 +64,11 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 use codec::{Decode, Encode, EncodeLike, FullCodec};
-use da_primitives::{asdr::AppExtrinsic, traits::ExtendedHeader, BLOCK_CHUNK_SIZE};
+use da_primitives::{
+	asdr::{AppExtrinsic, AppId},
+	traits::ExtendedHeader,
+	BLOCK_CHUNK_SIZE,
+};
 #[cfg(feature = "std")]
 use frame_support::traits::GenesisBuild;
 use frame_support::{
@@ -331,7 +335,9 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_runtime_upgrade() -> frame_support::weights::Weight { migrations::migrate::<T>() }
+		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+			migrations::migrate::<T>()
+		}
 
 		fn integrity_test() {
 			T::BlockWeights::get()
@@ -713,7 +719,9 @@ pub enum Phase {
 }
 
 impl Default for Phase {
-	fn default() -> Self { Self::Initialization }
+	fn default() -> Self {
+		Self::Initialization
+	}
 }
 
 /// Record of an event happening.
@@ -828,7 +836,9 @@ impl<O: Into<Result<RawOrigin<AccountId>, O>> + From<RawOrigin<AccountId>>, Acco
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	fn successful_origin() -> O { O::from(RawOrigin::Root) }
+	fn successful_origin() -> O {
+		O::from(RawOrigin::Root)
+	}
 }
 
 pub struct EnsureSigned<AccountId>(sp_std::marker::PhantomData<AccountId>);
@@ -845,7 +855,9 @@ impl<O: Into<Result<RawOrigin<AccountId>, O>> + From<RawOrigin<AccountId>>, Acco
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	fn successful_origin() -> O { O::from(RawOrigin::Signed(Default::default())) }
+	fn successful_origin() -> O {
+		O::from(RawOrigin::Signed(Default::default()))
+	}
 }
 
 pub struct EnsureSignedBy<Who, AccountId>(sp_std::marker::PhantomData<(Who, AccountId)>);
@@ -889,17 +901,23 @@ impl<O: Into<Result<RawOrigin<AccountId>, O>> + From<RawOrigin<AccountId>>, Acco
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	fn successful_origin() -> O { O::from(RawOrigin::None) }
+	fn successful_origin() -> O {
+		O::from(RawOrigin::None)
+	}
 }
 
 pub struct EnsureNever<T>(sp_std::marker::PhantomData<T>);
 impl<O, T> EnsureOrigin<O> for EnsureNever<T> {
 	type Success = T;
 
-	fn try_origin(o: O) -> Result<Self::Success, O> { Err(o) }
+	fn try_origin(o: O) -> Result<Self::Success, O> {
+		Err(o)
+	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	fn successful_origin() -> O { unimplemented!() }
+	fn successful_origin() -> O {
+		unimplemented!()
+	}
 }
 
 /// The "OR gate" implementation of `EnsureOrigin`.
@@ -923,7 +941,9 @@ impl<
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	fn successful_origin() -> O { L::successful_origin() }
+	fn successful_origin() -> O {
+		L::successful_origin()
+	}
 }
 
 /// Ensure that the origin `o` represents a signed extrinsic (i.e. transaction).
@@ -976,7 +996,9 @@ pub enum InitKind {
 }
 
 impl Default for InitKind {
-	fn default() -> Self { InitKind::Full }
+	fn default() -> Self {
+		InitKind::Full
+	}
 }
 
 /// Reference status; can be either referenced or unreferenced.
@@ -1005,7 +1027,9 @@ pub enum DecRefStatus {
 }
 
 impl<T: Config> Pallet<T> {
-	pub fn account_exists(who: &T::AccountId) -> bool { Account::<T>::contains_key(who) }
+	pub fn account_exists(who: &T::AccountId) -> bool {
+		Account::<T>::contains_key(who)
+	}
 
 	/// Write code to the storage and emit related events and digest items.
 	///
@@ -1021,20 +1045,28 @@ impl<T: Config> Pallet<T> {
 
 	/// Increment the reference counter on an account.
 	#[deprecated = "Use `inc_consumers` instead"]
-	pub fn inc_ref(who: &T::AccountId) { let _ = Self::inc_consumers(who); }
+	pub fn inc_ref(who: &T::AccountId) {
+		let _ = Self::inc_consumers(who);
+	}
 
 	/// Decrement the reference counter on an account. This *MUST* only be done once for every time
 	/// you called `inc_consumers` on `who`.
 	#[deprecated = "Use `dec_consumers` instead"]
-	pub fn dec_ref(who: &T::AccountId) { let _ = Self::dec_consumers(who); }
+	pub fn dec_ref(who: &T::AccountId) {
+		let _ = Self::dec_consumers(who);
+	}
 
 	/// The number of outstanding references for the account `who`.
 	#[deprecated = "Use `consumers` instead"]
-	pub fn refs(who: &T::AccountId) -> RefCount { Self::consumers(who) }
+	pub fn refs(who: &T::AccountId) -> RefCount {
+		Self::consumers(who)
+	}
 
 	/// True if the account has no outstanding references.
 	#[deprecated = "Use `!is_provider_required` instead"]
-	pub fn allow_death(who: &T::AccountId) -> bool { !Self::is_provider_required(who) }
+	pub fn allow_death(who: &T::AccountId) -> bool {
+		!Self::is_provider_required(who)
+	}
 
 	/// Increment the provider reference counter on an account.
 	pub fn inc_providers(who: &T::AccountId) -> IncRefStatus {
@@ -1144,10 +1176,14 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// The number of outstanding provider references for the account `who`.
-	pub fn providers(who: &T::AccountId) -> RefCount { Account::<T>::get(who).providers }
+	pub fn providers(who: &T::AccountId) -> RefCount {
+		Account::<T>::get(who).providers
+	}
 
 	/// The number of outstanding sufficient references for the account `who`.
-	pub fn sufficients(who: &T::AccountId) -> RefCount { Account::<T>::get(who).sufficients }
+	pub fn sufficients(who: &T::AccountId) -> RefCount {
+		Account::<T>::get(who).sufficients
+	}
 
 	/// The number of outstanding provider and sufficient references for the account `who`.
 	pub fn reference_count(who: &T::AccountId) -> RefCount {
@@ -1185,7 +1221,9 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// The number of outstanding references for the account `who`.
-	pub fn consumers(who: &T::AccountId) -> RefCount { Account::<T>::get(who).consumers }
+	pub fn consumers(who: &T::AccountId) -> RefCount {
+		Account::<T>::get(who).consumers
+	}
 
 	/// True if the account has some outstanding consumer references.
 	pub fn is_provider_required(who: &T::AccountId) -> bool {
@@ -1199,7 +1237,9 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// True if the account has at least one provider reference.
-	pub fn can_inc_consumer(who: &T::AccountId) -> bool { Account::<T>::get(who).providers > 0 }
+	pub fn can_inc_consumer(who: &T::AccountId) -> bool {
+		Account::<T>::get(who).providers > 0
+	}
 
 	/// Deposits an event into this block's event record.
 	pub fn deposit_event(event: impl Into<T::Event>) {
@@ -1251,10 +1291,14 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Gets extrinsics count.
-	pub fn extrinsic_count() -> u32 { ExtrinsicCount::<T>::get().unwrap_or_default() }
+	pub fn extrinsic_count() -> u32 {
+		ExtrinsicCount::<T>::get().unwrap_or_default()
+	}
 
 	/// Returns all extrinsics len in raw.
-	pub fn all_extrinsics_len() -> u32 { AllExtrinsicsLen::<T>::get().unwrap_or_default().raw }
+	pub fn all_extrinsics_len() -> u32 {
+		AllExtrinsicsLen::<T>::get().unwrap_or_default().raw
+	}
 
 	/// Returns all extrinsics len with padding.
 	pub fn all_padded_extrinsics_len() -> u32 {
@@ -1351,7 +1395,9 @@ impl<T: Config> Pallet<T> {
 	/// - `O(1)`
 	/// - 1 storage write (codec `O(1)`)
 	/// # </weight>
-	pub fn deposit_log(item: generic::DigestItem) { <Digest<T>>::append(item); }
+	pub fn deposit_log(item: generic::DigestItem) {
+		<Digest<T>>::append(item);
+	}
 
 	/// Get the basic externalities for this pallet, useful for tests.
 	#[cfg(any(feature = "std", test))]
@@ -1372,18 +1418,24 @@ impl<T: Config> Pallet<T> {
 	/// impact on the PoV size of a block. Users should use alternative and well bounded storage
 	/// items for any behavior like this.
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
-	pub fn events() -> Vec<EventRecord<T::Event, T::Hash>> { Self::read_events_no_consensus() }
+	pub fn events() -> Vec<EventRecord<T::Event, T::Hash>> {
+		Self::read_events_no_consensus()
+	}
 
 	/// Get the current events deposited by the runtime.
 	///
 	/// Should only be called if you know what you are doing and outside of the runtime block
 	/// execution else it can have a large impact on the PoV size of a block.
-	pub fn read_events_no_consensus() -> Vec<EventRecord<T::Event, T::Hash>> { Events::<T>::get() }
+	pub fn read_events_no_consensus() -> Vec<EventRecord<T::Event, T::Hash>> {
+		Events::<T>::get()
+	}
 
 	/// Set the block number to something in particular. Can be used as an alternative to
 	/// `initialize` for tests that don't need to bother with the other environment entries.
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
-	pub fn set_block_number(n: T::BlockNumber) { <Number<T>>::put(n); }
+	pub fn set_block_number(n: T::BlockNumber) {
+		<Number<T>>::put(n);
+	}
 
 	/// Sets the index of extrinsic that is currently executing.
 	#[cfg(any(feature = "std", test))]
@@ -1394,7 +1446,9 @@ impl<T: Config> Pallet<T> {
 	/// Set the parent hash number to something in particular. Can be used as an alternative to
 	/// `initialize` for tests that don't need to bother with the other environment entries.
 	#[cfg(any(feature = "std", test))]
-	pub fn set_parent_hash(n: T::Hash) { <ParentHash<T>>::put(n); }
+	pub fn set_parent_hash(n: T::Hash) {
+		<ParentHash<T>>::put(n);
+	}
 
 	/// Set the current block weight. This should only be used in some integration tests.
 	#[cfg(any(feature = "std", test))]
@@ -1431,7 +1485,9 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Return the chain's current runtime version.
-	pub fn runtime_version() -> RuntimeVersion { T::Version::get() }
+	pub fn runtime_version() -> RuntimeVersion {
+		T::Version::get()
+	}
 
 	/// Retrieve the account transaction counter from storage.
 	pub fn account_nonce(who: impl EncodeLike<T::AccountId>) -> T::Index {
@@ -1447,12 +1503,15 @@ impl<T: Config> Pallet<T> {
 	///
 	/// This is required to be called before applying an extrinsic. The data will used
 	/// in [`Self::finalize`] to calculate the correct extrinsics root.
-	pub fn note_extrinsic(app_id: u32, encoded_xt: Vec<u8>) {
+	pub fn note_extrinsic(app_id: AppId, encoded_xt: Vec<u8>) {
 		let idx = Self::extrinsic_index().unwrap_or_default();
-		ExtrinsicData::<T>::insert(idx, AppExtrinsic {
-			app_id,
-			data: encoded_xt,
-		});
+		ExtrinsicData::<T>::insert(
+			idx,
+			AppExtrinsic {
+				app_id,
+				data: encoded_xt,
+			},
+		);
 	}
 
 	/// To be called immediately after an extrinsic has been applied.
@@ -1488,7 +1547,9 @@ impl<T: Config> Pallet<T> {
 
 	/// To be called immediately after finishing the initialization of the block
 	/// (e.g., called `on_initialize` for all pallets).
-	pub fn note_finished_initialize() { ExecutionPhase::<T>::put(Phase::ApplyExtrinsic(0)) }
+	pub fn note_finished_initialize() {
+		ExecutionPhase::<T>::put(Phase::ApplyExtrinsic(0))
+	}
 
 	/// An account is being created.
 	pub fn on_created_account(who: T::AccountId, _a: &mut AccountInfo<T::Index, T::AccountData>) {
@@ -1570,7 +1631,9 @@ impl<T: Config> HandleLifetime<T::AccountId> for SelfSufficient<T> {
 /// Event handler which registers a consumer when created.
 pub struct Consumer<T>(PhantomData<T>);
 impl<T: Config> HandleLifetime<T::AccountId> for Consumer<T> {
-	fn created(t: &T::AccountId) -> Result<(), DispatchError> { Pallet::<T>::inc_consumers(t) }
+	fn created(t: &T::AccountId) -> Result<(), DispatchError> {
+		Pallet::<T>::inc_consumers(t)
+	}
 
 	fn killed(t: &T::AccountId) -> Result<(), DispatchError> {
 		Pallet::<T>::dec_consumers(t);
@@ -1581,10 +1644,14 @@ impl<T: Config> HandleLifetime<T::AccountId> for Consumer<T> {
 impl<T: Config> BlockNumberProvider for Pallet<T> {
 	type BlockNumber = <T as Config>::BlockNumber;
 
-	fn current_block_number() -> Self::BlockNumber { Pallet::<T>::block_number() }
+	fn current_block_number() -> Self::BlockNumber {
+		Pallet::<T>::block_number()
+	}
 }
 
-fn is_providing<T: Default + Eq>(d: &T) -> bool { d != &T::default() }
+fn is_providing<T: Default + Eq>(d: &T) -> bool {
+	d != &T::default()
+}
 
 /// Implement StoredMap for a simple single-item, provide-when-not-default system. This works fine
 /// for storing a single item which allows the account to continue existing as long as it's not
@@ -1592,7 +1659,9 @@ fn is_providing<T: Default + Eq>(d: &T) -> bool { d != &T::default() }
 ///
 /// Anything more complex will need more sophisticated logic.
 impl<T: Config> StoredMap<T::AccountId, T::AccountData> for Pallet<T> {
-	fn get(k: &T::AccountId) -> T::AccountData { Account::<T>::get(k).data }
+	fn get(k: &T::AccountId) -> T::AccountData {
+		Account::<T>::get(k).data
+	}
 
 	fn try_mutate_exists<R, E: From<DispatchError>>(
 		k: &T::AccountId,
@@ -1640,7 +1709,9 @@ pub fn split_inner<T, R, S>(
 
 pub struct ChainContext<T>(PhantomData<T>);
 impl<T> Default for ChainContext<T> {
-	fn default() -> Self { ChainContext(PhantomData) }
+	fn default() -> Self {
+		ChainContext(PhantomData)
+	}
 }
 
 impl<T: Config> Lookup for ChainContext<T> {

--- a/pallets/system/src/limits.rs
+++ b/pallets/system/src/limits.rs
@@ -49,8 +49,11 @@ pub struct BlockLength {
 	/// `MAX(max)`
 	#[cfg_attr(feature = "std", serde(with = "per_dispatch_class_serde"))]
 	pub max: PerDispatchClass<u32>,
+	#[codec(compact)]
 	pub cols: u32,
+	#[codec(compact)]
 	pub rows: u32,
+	#[codec(compact)]
 	chunk_size: u32,
 }
 

--- a/pallets/system/src/mock.rs
+++ b/pallets/system/src/mock.rs
@@ -86,6 +86,12 @@ impl OnKilledAccount<u64> for RecordKilled {
 	fn on_killed_account(who: &u64) { KILLED.with(|r| r.borrow_mut().push(*who)) }
 }
 
+impl DataRootFilter for Test {
+	type UncheckedExtrinsic = UncheckedExtrinsic;
+
+	fn filter(_call: &DRFCallOf<Self::UncheckedExtrinsic>) -> DRFOutput { None }
+}
+
 impl Config for Test {
 	type AccountData = u32;
 	type AccountId = u64;
@@ -95,12 +101,13 @@ impl Config for Test {
 	type BlockNumber = BlockNumber;
 	type BlockWeights = RuntimeBlockWeights;
 	type Call = Call;
+	type DataRootBuilderFilter = Test;
 	type DbWeight = DbWeight;
 	type Event = Event;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Header = da_primitives::Header<BlockNumber, BlakeTwo256>;
-	type HeaderBuilder = frame_system::header_builder::da::HeaderBuilder<Test>;
+	type HeaderExtensionBuilder = frame_system::header_builder::da::HeaderExtensionBuilder<Test>;
 	type Index = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type OnKilledAccount = RecordKilled;

--- a/pallets/system/src/tests.rs
+++ b/pallets/system/src/tests.rs
@@ -49,9 +49,7 @@ mod tests {
 
 	use crate::*;
 
-	fn extrinsics_data_root<H: Hash>(xts: Vec<Vec<u8>>) -> H::Output {
-		H::ordered_trie_root(xts)
-	}
+	fn extrinsics_data_root<H: Hash>(xts: Vec<Vec<u8>>) -> H::Output { H::ordered_trie_root(xts) }
 
 	#[test]
 	fn origin_works() {
@@ -66,16 +64,13 @@ mod tests {
 			assert_ok!(System::insert(&0, 42));
 			assert!(!System::is_provider_required(&0));
 
-			assert_eq!(
-				Account::<Test>::get(0),
-				AccountInfo {
-					nonce: 0,
-					providers: 1,
-					consumers: 0,
-					sufficients: 0,
-					data: 42
-				}
-			);
+			assert_eq!(Account::<Test>::get(0), AccountInfo {
+				nonce: 0,
+				providers: 1,
+				consumers: 0,
+				sufficients: 0,
+				data: 42
+			});
 
 			assert_ok!(System::inc_consumers(&0));
 			assert!(System::is_provider_required(&0));
@@ -191,14 +186,11 @@ mod tests {
 			System::note_finished_extrinsics();
 			System::deposit_event(SysEvent::CodeUpdated);
 			System::finalize();
-			assert_eq!(
-				System::events(),
-				vec![EventRecord {
-					phase: Phase::Finalization,
-					event: SysEvent::CodeUpdated.into(),
-					topics: vec![],
-				}]
-			);
+			assert_eq!(System::events(), vec![EventRecord {
+				phase: Phase::Finalization,
+				event: SysEvent::CodeUpdated.into(),
+				topics: vec![],
+			}]);
 
 			System::initialize(&2, &[0u8; 32].into(), &Default::default(), InitKind::Full);
 			System::deposit_event(SysEvent::NewAccount(32));
@@ -212,40 +204,37 @@ mod tests {
 			System::note_finished_extrinsics();
 			System::deposit_event(SysEvent::NewAccount(3));
 			System::finalize();
-			assert_eq!(
-				System::events(),
-				vec![
-					EventRecord {
-						phase: Phase::Initialization,
-						event: SysEvent::NewAccount(32).into(),
-						topics: vec![],
-					},
-					EventRecord {
-						phase: Phase::ApplyExtrinsic(0),
-						event: SysEvent::KilledAccount(42).into(),
-						topics: vec![]
-					},
-					EventRecord {
-						phase: Phase::ApplyExtrinsic(0),
-						event: SysEvent::ExtrinsicSuccess(Default::default()).into(),
-						topics: vec![]
-					},
-					EventRecord {
-						phase: Phase::ApplyExtrinsic(1),
-						event: SysEvent::ExtrinsicFailed(
-							DispatchError::BadOrigin.into(),
-							Default::default()
-						)
-						.into(),
-						topics: vec![]
-					},
-					EventRecord {
-						phase: Phase::Finalization,
-						event: SysEvent::NewAccount(3).into(),
-						topics: vec![]
-					},
-				]
-			);
+			assert_eq!(System::events(), vec![
+				EventRecord {
+					phase: Phase::Initialization,
+					event: SysEvent::NewAccount(32).into(),
+					topics: vec![],
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(0),
+					event: SysEvent::KilledAccount(42).into(),
+					topics: vec![]
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(0),
+					event: SysEvent::ExtrinsicSuccess(Default::default()).into(),
+					topics: vec![]
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(1),
+					event: SysEvent::ExtrinsicFailed(
+						DispatchError::BadOrigin.into(),
+						Default::default()
+					)
+					.into(),
+					topics: vec![]
+				},
+				EventRecord {
+					phase: Phase::Finalization,
+					event: SysEvent::NewAccount(3).into(),
+					topics: vec![]
+				},
+			]);
 		});
 	}
 
@@ -271,50 +260,47 @@ mod tests {
 				pre_info,
 			);
 
-			assert_eq!(
-				System::events(),
-				vec![
-					EventRecord {
-						phase: Phase::ApplyExtrinsic(0),
-						event: SysEvent::ExtrinsicSuccess(DispatchInfo {
-							weight: 300,
+			assert_eq!(System::events(), vec![
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(0),
+					event: SysEvent::ExtrinsicSuccess(DispatchInfo {
+						weight: 300,
+						..Default::default()
+					},)
+					.into(),
+					topics: vec![]
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(1),
+					event: SysEvent::ExtrinsicSuccess(DispatchInfo {
+						weight: 1000,
+						..Default::default()
+					},)
+					.into(),
+					topics: vec![]
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(2),
+					event: SysEvent::ExtrinsicSuccess(DispatchInfo {
+						weight: 1000,
+						..Default::default()
+					},)
+					.into(),
+					topics: vec![]
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(3),
+					event: SysEvent::ExtrinsicFailed(
+						DispatchError::BadOrigin.into(),
+						DispatchInfo {
+							weight: 999,
 							..Default::default()
-						},)
-						.into(),
-						topics: vec![]
-					},
-					EventRecord {
-						phase: Phase::ApplyExtrinsic(1),
-						event: SysEvent::ExtrinsicSuccess(DispatchInfo {
-							weight: 1000,
-							..Default::default()
-						},)
-						.into(),
-						topics: vec![]
-					},
-					EventRecord {
-						phase: Phase::ApplyExtrinsic(2),
-						event: SysEvent::ExtrinsicSuccess(DispatchInfo {
-							weight: 1000,
-							..Default::default()
-						},)
-						.into(),
-						topics: vec![]
-					},
-					EventRecord {
-						phase: Phase::ApplyExtrinsic(3),
-						event: SysEvent::ExtrinsicFailed(
-							DispatchError::BadOrigin.into(),
-							DispatchInfo {
-								weight: 999,
-								..Default::default()
-							},
-						)
-						.into(),
-						topics: vec![]
-					},
-				]
-			);
+						},
+					)
+					.into(),
+					topics: vec![]
+				},
+			]);
 		});
 	}
 
@@ -345,37 +331,34 @@ mod tests {
 			System::finalize();
 
 			// Check that topics are reflected in the event record.
-			assert_eq!(
-				System::events(),
-				vec![
-					EventRecord {
-						phase: Phase::Finalization,
-						event: SysEvent::NewAccount(1).into(),
-						topics: topics[0..3].to_vec(),
-					},
-					EventRecord {
-						phase: Phase::Finalization,
-						event: SysEvent::NewAccount(2).into(),
-						topics: topics[0..1].to_vec(),
-					},
-					EventRecord {
-						phase: Phase::Finalization,
-						event: SysEvent::NewAccount(3).into(),
-						topics: topics[1..2].to_vec(),
-					}
-				]
-			);
+			assert_eq!(System::events(), vec![
+				EventRecord {
+					phase: Phase::Finalization,
+					event: SysEvent::NewAccount(1).into(),
+					topics: topics[0..3].to_vec(),
+				},
+				EventRecord {
+					phase: Phase::Finalization,
+					event: SysEvent::NewAccount(2).into(),
+					topics: topics[0..1].to_vec(),
+				},
+				EventRecord {
+					phase: Phase::Finalization,
+					event: SysEvent::NewAccount(3).into(),
+					topics: topics[1..2].to_vec(),
+				}
+			]);
 
 			// Check that the topic-events mapping reflects the deposited topics.
 			// Note that these are indexes of the events.
-			assert_eq!(
-				System::event_topics(&topics[0]),
-				vec![(BLOCK_NUMBER, 0), (BLOCK_NUMBER, 1)]
-			);
-			assert_eq!(
-				System::event_topics(&topics[1]),
-				vec![(BLOCK_NUMBER, 0), (BLOCK_NUMBER, 2)]
-			);
+			assert_eq!(System::event_topics(&topics[0]), vec![
+				(BLOCK_NUMBER, 0),
+				(BLOCK_NUMBER, 1)
+			]);
+			assert_eq!(System::event_topics(&topics[1]), vec![
+				(BLOCK_NUMBER, 0),
+				(BLOCK_NUMBER, 2)
+			]);
 			assert_eq!(System::event_topics(&topics[2]), vec![(BLOCK_NUMBER, 0)]);
 		});
 	}

--- a/pallets/system/src/tests.rs
+++ b/pallets/system/src/tests.rs
@@ -49,7 +49,9 @@ mod tests {
 
 	use crate::*;
 
-	fn extrinsics_data_root<H: Hash>(xts: Vec<Vec<u8>>) -> H::Output { H::ordered_trie_root(xts) }
+	fn extrinsics_data_root<H: Hash>(xts: Vec<Vec<u8>>) -> H::Output {
+		H::ordered_trie_root(xts)
+	}
 
 	#[test]
 	fn origin_works() {
@@ -64,13 +66,16 @@ mod tests {
 			assert_ok!(System::insert(&0, 42));
 			assert!(!System::is_provider_required(&0));
 
-			assert_eq!(Account::<Test>::get(0), AccountInfo {
-				nonce: 0,
-				providers: 1,
-				consumers: 0,
-				sufficients: 0,
-				data: 42
-			});
+			assert_eq!(
+				Account::<Test>::get(0),
+				AccountInfo {
+					nonce: 0,
+					providers: 1,
+					consumers: 0,
+					sufficients: 0,
+					data: 42
+				}
+			);
 
 			assert_ok!(System::inc_consumers(&0));
 			assert!(System::is_provider_required(&0));
@@ -186,11 +191,14 @@ mod tests {
 			System::note_finished_extrinsics();
 			System::deposit_event(SysEvent::CodeUpdated);
 			System::finalize();
-			assert_eq!(System::events(), vec![EventRecord {
-				phase: Phase::Finalization,
-				event: SysEvent::CodeUpdated.into(),
-				topics: vec![],
-			}]);
+			assert_eq!(
+				System::events(),
+				vec![EventRecord {
+					phase: Phase::Finalization,
+					event: SysEvent::CodeUpdated.into(),
+					topics: vec![],
+				}]
+			);
 
 			System::initialize(&2, &[0u8; 32].into(), &Default::default(), InitKind::Full);
 			System::deposit_event(SysEvent::NewAccount(32));
@@ -204,37 +212,40 @@ mod tests {
 			System::note_finished_extrinsics();
 			System::deposit_event(SysEvent::NewAccount(3));
 			System::finalize();
-			assert_eq!(System::events(), vec![
-				EventRecord {
-					phase: Phase::Initialization,
-					event: SysEvent::NewAccount(32).into(),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: SysEvent::KilledAccount(42).into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: SysEvent::ExtrinsicSuccess(Default::default()).into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(1),
-					event: SysEvent::ExtrinsicFailed(
-						DispatchError::BadOrigin.into(),
-						Default::default()
-					)
-					.into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::Finalization,
-					event: SysEvent::NewAccount(3).into(),
-					topics: vec![]
-				},
-			]);
+			assert_eq!(
+				System::events(),
+				vec![
+					EventRecord {
+						phase: Phase::Initialization,
+						event: SysEvent::NewAccount(32).into(),
+						topics: vec![],
+					},
+					EventRecord {
+						phase: Phase::ApplyExtrinsic(0),
+						event: SysEvent::KilledAccount(42).into(),
+						topics: vec![]
+					},
+					EventRecord {
+						phase: Phase::ApplyExtrinsic(0),
+						event: SysEvent::ExtrinsicSuccess(Default::default()).into(),
+						topics: vec![]
+					},
+					EventRecord {
+						phase: Phase::ApplyExtrinsic(1),
+						event: SysEvent::ExtrinsicFailed(
+							DispatchError::BadOrigin.into(),
+							Default::default()
+						)
+						.into(),
+						topics: vec![]
+					},
+					EventRecord {
+						phase: Phase::Finalization,
+						event: SysEvent::NewAccount(3).into(),
+						topics: vec![]
+					},
+				]
+			);
 		});
 	}
 
@@ -260,47 +271,50 @@ mod tests {
 				pre_info,
 			);
 
-			assert_eq!(System::events(), vec![
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: SysEvent::ExtrinsicSuccess(DispatchInfo {
-						weight: 300,
-						..Default::default()
-					},)
-					.into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(1),
-					event: SysEvent::ExtrinsicSuccess(DispatchInfo {
-						weight: 1000,
-						..Default::default()
-					},)
-					.into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(2),
-					event: SysEvent::ExtrinsicSuccess(DispatchInfo {
-						weight: 1000,
-						..Default::default()
-					},)
-					.into(),
-					topics: vec![]
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(3),
-					event: SysEvent::ExtrinsicFailed(
-						DispatchError::BadOrigin.into(),
-						DispatchInfo {
-							weight: 999,
+			assert_eq!(
+				System::events(),
+				vec![
+					EventRecord {
+						phase: Phase::ApplyExtrinsic(0),
+						event: SysEvent::ExtrinsicSuccess(DispatchInfo {
+							weight: 300,
 							..Default::default()
-						},
-					)
-					.into(),
-					topics: vec![]
-				},
-			]);
+						},)
+						.into(),
+						topics: vec![]
+					},
+					EventRecord {
+						phase: Phase::ApplyExtrinsic(1),
+						event: SysEvent::ExtrinsicSuccess(DispatchInfo {
+							weight: 1000,
+							..Default::default()
+						},)
+						.into(),
+						topics: vec![]
+					},
+					EventRecord {
+						phase: Phase::ApplyExtrinsic(2),
+						event: SysEvent::ExtrinsicSuccess(DispatchInfo {
+							weight: 1000,
+							..Default::default()
+						},)
+						.into(),
+						topics: vec![]
+					},
+					EventRecord {
+						phase: Phase::ApplyExtrinsic(3),
+						event: SysEvent::ExtrinsicFailed(
+							DispatchError::BadOrigin.into(),
+							DispatchInfo {
+								weight: 999,
+								..Default::default()
+							},
+						)
+						.into(),
+						topics: vec![]
+					},
+				]
+			);
 		});
 	}
 
@@ -331,34 +345,37 @@ mod tests {
 			System::finalize();
 
 			// Check that topics are reflected in the event record.
-			assert_eq!(System::events(), vec![
-				EventRecord {
-					phase: Phase::Finalization,
-					event: SysEvent::NewAccount(1).into(),
-					topics: topics[0..3].to_vec(),
-				},
-				EventRecord {
-					phase: Phase::Finalization,
-					event: SysEvent::NewAccount(2).into(),
-					topics: topics[0..1].to_vec(),
-				},
-				EventRecord {
-					phase: Phase::Finalization,
-					event: SysEvent::NewAccount(3).into(),
-					topics: topics[1..2].to_vec(),
-				}
-			]);
+			assert_eq!(
+				System::events(),
+				vec![
+					EventRecord {
+						phase: Phase::Finalization,
+						event: SysEvent::NewAccount(1).into(),
+						topics: topics[0..3].to_vec(),
+					},
+					EventRecord {
+						phase: Phase::Finalization,
+						event: SysEvent::NewAccount(2).into(),
+						topics: topics[0..1].to_vec(),
+					},
+					EventRecord {
+						phase: Phase::Finalization,
+						event: SysEvent::NewAccount(3).into(),
+						topics: topics[1..2].to_vec(),
+					}
+				]
+			);
 
 			// Check that the topic-events mapping reflects the deposited topics.
 			// Note that these are indexes of the events.
-			assert_eq!(System::event_topics(&topics[0]), vec![
-				(BLOCK_NUMBER, 0),
-				(BLOCK_NUMBER, 1)
-			]);
-			assert_eq!(System::event_topics(&topics[1]), vec![
-				(BLOCK_NUMBER, 0),
-				(BLOCK_NUMBER, 2)
-			]);
+			assert_eq!(
+				System::event_topics(&topics[0]),
+				vec![(BLOCK_NUMBER, 0), (BLOCK_NUMBER, 1)]
+			);
+			assert_eq!(
+				System::event_topics(&topics[1]),
+				vec![(BLOCK_NUMBER, 0), (BLOCK_NUMBER, 2)]
+			);
 			assert_eq!(System::event_topics(&topics[2]), vec![(BLOCK_NUMBER, 0)]);
 		});
 	}
@@ -531,9 +548,9 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			System::initialize(&1, &[0u8; 32].into(), &Default::default(), InitKind::Full);
 			System::note_finished_initialize();
-			System::note_extrinsic(0, vec![1]);
+			System::note_extrinsic(0.into(), vec![1]);
 			System::note_applied_extrinsic(&Ok(().into()), Default::default());
-			System::note_extrinsic(0, vec![2]);
+			System::note_extrinsic(0.into(), vec![2]);
 			System::note_applied_extrinsic(
 				&Err(DispatchError::BadOrigin.into()),
 				Default::default(),
@@ -542,8 +559,7 @@ mod tests {
 			let header = System::finalize();
 
 			let ext_root = extrinsics_data_root::<BlakeTwo256>(vec![vec![1], vec![2]]);
-			let expected = da_primitives::traits::ExtendedHeader::extrinsics_root(&header);
-			assert_eq!(ext_root, expected.hash);
+			assert_eq!(ext_root, header.extrinsics_root);
 		});
 	}
 

--- a/rpc/kate-rpc/Cargo.toml
+++ b/rpc/kate-rpc/Cargo.toml
@@ -28,3 +28,4 @@ sc-client-api = { version = "4.0.0-dev" }
 sp-blockchain = { version = "4.0.0-dev" }
 sp-rpc = { version = "4.0.0-dev" }
 sp-runtime = { version = "4.0.0-dev" }
+sp-core = { version = "4.0.0-dev" }

--- a/rpc/kate-rpc/Cargo.toml
+++ b/rpc/kate-rpc/Cargo.toml
@@ -15,8 +15,8 @@ sc-client-db = { version = "0.10.0-dev", default-features = false }
 rs_merkle = { version = "1.2.0", default-features = false }
 
 codec = { package = "parity-scale-codec", version = "2.0.0" }
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
 
 frame-system-rpc-runtime-api = "4.0.0-dev"
 jsonrpc-core = "18.0.0"

--- a/rpc/kate-rpc/Cargo.toml
+++ b/rpc/kate-rpc/Cargo.toml
@@ -15,8 +15,8 @@ sc-client-db = { version = "0.10.0-dev", default-features = false }
 rs_merkle = { version = "1.2.0", default-features = false }
 
 codec = { package = "parity-scale-codec", version = "2.0.0" }
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
 
 frame-system-rpc-runtime-api = "4.0.0-dev"
 jsonrpc-core = "18.0.0"

--- a/rpc/kate-rpc/Cargo.toml
+++ b/rpc/kate-rpc/Cargo.toml
@@ -15,8 +15,8 @@ sc-client-db = { version = "0.10.0-dev", default-features = false }
 rs_merkle = { version = "1.2.0", default-features = false }
 
 codec = { package = "parity-scale-codec", version = "2.0.0" }
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
 
 frame-system-rpc-runtime-api = "4.0.0-dev"
 jsonrpc-core = "18.0.0"

--- a/rpc/kate-rpc/src/lib.rs
+++ b/rpc/kate-rpc/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use codec::{Compact, Decode, Encode, Error as DecodeError, Input};
-use da_primitives::asdr::{AppExtrinsic, AppId, GetAppId};
+use da_primitives::asdr::{AppExtrinsic, GetAppId};
 use frame_system::limits::BlockLength;
 use jsonrpc_core::{Error as RpcError, Result};
 use jsonrpc_derive::rpc;
@@ -83,7 +83,7 @@ macro_rules! internal_err {
 impl<Client, Block> KateApi for Kate<Client, Block>
 where
 	Block: BlockT,
-	Block::Extrinsic: GetAppId<AppId>,
+	Block::Extrinsic: GetAppId,
 	Client: Send + Sync + 'static,
 	Client: HeaderBackend<Block>
 		+ ProvideRuntimeApi<Block>

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,8 +13,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # Internal
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
 da-control = { path = "../pallets/dactr", default-features = false }
 kate-rpc-runtime-api = { path = "../rpc/kate-rpc-runtime-api", default-features = false }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -26,6 +26,7 @@ da-bridge = { path = "../pallets/nomad/da-bridge", default-features = false }
 # External 
 static_assertions = "1.1.0"
 serde = { version = "1.0.121", optional = true, features = ["derive"] }
+log = { version = "0.4.14", default-features = false }
 
 # Substrate
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
@@ -108,6 +109,7 @@ default = ["std"]
 std = [
 	"serde",
 	"parity-util-mem/std",
+	"log/std",
 	"da-primitives/std",
 	"sp-io/std", 
 	"sp-core/std", 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,8 +13,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # Internal
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.0", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "v0.2.1", default-features = false }
 da-control = { path = "../pallets/dactr", default-features = false }
 kate-rpc-runtime-api = { path = "../rpc/kate-rpc-runtime-api", default-features = false }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,8 +13,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # Internal
-da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
-kate = { git = "https://github.com/maticnetwork/avail-core.git", tag = "kate/v0.2.1", default-features = false }
+da-primitives = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
+kate = { git = "https://github.com/maticnetwork/avail-core.git", branch = "miguel/ava-397-compatibility-issue-between-10-11", default-features = false }
 da-control = { path = "../pallets/dactr", default-features = false }
 kate-rpc-runtime-api = { path = "../rpc/kate-rpc-runtime-api", default-features = false }
 

--- a/runtime/src/data_root_tests.rs
+++ b/runtime/src/data_root_tests.rs
@@ -1,0 +1,69 @@
+use da_control::CheckAppId;
+use da_primitives::asdr::AppExtrinsic;
+use frame_system::{CheckNonce, DataRootBuilder};
+use hex_literal::hex;
+use pallet_transaction_payment::ChargeTransactionPayment;
+use sp_core::{sr25519::Signature, H256};
+use sp_runtime::{generic::Era, AccountId32, MultiAddress};
+use test_case::test_case;
+
+use super::*;
+
+fn submit_call<A: Into<AppId>>(app_id: A) -> AppExtrinsic {
+	let data = hex!("ed018400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d01be06880f2f6203365b508b4226fd697d3d79d3a50a5617aad714466d40ef47067225e823135b32121aa0f6f56e696f5f71107a6d44768c2fefe38cb209f7f28224000000041d014054657374207375626d69742064617461").to_vec();
+	AppExtrinsic {
+		app_id: app_id.into(),
+		data,
+	}
+}
+fn submit_call_expected() -> H256 {
+	// hex!("ddf368647a902a6f6ab9f53b32245be28edc99e92f43f0004bbc2cb359814b2a").into()
+	// hex!("9c6cf805b377632c6a224e1ca035f8f6975932529a5e492e73742e4f861ba89d").into()
+	hex!("66dde8b32cbd3e6c3ae02f570a23202413d67870b15354c17cc12c4c49894c55").into()
+}
+
+#[test]
+fn decode_submit_call() {
+	let encoded_call = submit_call(1).data;
+
+	let call = super::UncheckedExtrinsic::decode(&mut encoded_call.as_slice()).unwrap();
+
+	let account = hex!("d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d");
+	let expected_signature = MultiSignature::Sr25519(Signature(hex!("be06880f2f6203365b508b4226fd697d3d79d3a50a5617aad714466d40ef47067225e823135b32121aa0f6f56e696f5f71107a6d44768c2fefe38cb209f7f282")));
+	let expected_call = AppUncheckedExtrinsic {
+		function: Call::DataAvailability(da_control::Call::submit_data {
+			data: hex!("54657374207375626d69742064617461")
+				.to_vec()
+				.try_into()
+				.unwrap(),
+		}),
+
+		// signature: Option<(Address, Signature, Extra)>,
+		signature: Some((
+			MultiAddress::Id(AccountId32::new(account)),
+			expected_signature.clone(),
+			// super::SignedExtra::default()
+			(
+				CheckSpecVersion::<Runtime>::new(),
+				CheckTxVersion::<Runtime>::new(),
+				CheckGenesis::<Runtime>::new(),
+				CheckEra::<Runtime>::from(Era::Mortal(32, 2)),
+				CheckNonce::<Runtime>::from(0),
+				CheckWeight::<Runtime>::new(),
+				ChargeTransactionPayment::<Runtime>::from(0),
+				CheckAppId::<Runtime>::from(1.into()),
+			),
+		)),
+	};
+
+	if let Some(ref signature) = call.signature {
+		assert_eq!(signature.1, expected_signature);
+	}
+	assert_eq!(call, expected_call);
+}
+
+#[test_case( submit_call(0) => submit_call_expected(); "Submit data 0")]
+#[test_case( submit_call(1) => submit_call_expected(); "Submit data 1")]
+fn data_root_filter(extrinsic: AppExtrinsic) -> H256 {
+	<Runtime as DataRootBuilder<Runtime>>::build(&[extrinsic])
+}


### PR DESCRIPTION
# Description
`Header` has been split into 2 parts:
 - A _common header_ which is similar to the generic substrate header,
 - And a _header extension_ field which supports **forward compatibility** using versions.
  
# Other changes
- Data Root build uses `beefy_merkle_tree` and supports `no-std`.