### PR TITLE
Switching to Nightly Toolchain

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -17,13 +17,15 @@ jobs:
            run: |
             curl https://sh.rustup.rs -sSf | sh -s -- -y
             source "$HOME/.cargo/env"
+            rustup toolchain install nightly
+            rustup default nightly
             cargo build --release -p data-avail
             mv target/release/data-avail target/release/data-avail-linux-amd64
          - uses: actions/upload-artifact@v2
            with:
              name: data-avail-linux-amd64-binary
              path: target/release/data-avail-linux-amd64
-             
+
   binary_linux_amd64_tar:
     runs-on: ubuntu-latest
     steps:
@@ -33,6 +35,8 @@ jobs:
            run: |
             curl https://sh.rustup.rs -sSf | sh -s -- -y
             source "$HOME/.cargo/env"
+            rustup toolchain install nightly
+            rustup default nightly
             cargo build --release -p data-avail
             mv target/release/data-avail target/release/data-avail-linux-amd64
             pushd target/release/
@@ -52,6 +56,8 @@ jobs:
            run: |
             curl https://sh.rustup.rs -sSf | sh -s -- -y
             source "$HOME/.cargo/env"
+            rustup toolchain install nightly
+            rustup default nightly
 
             rustup target add aarch64-unknown-linux-gnu
             sudo apt-get update && sudo apt-get install -y musl-tools clang gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev libc6-dev-arm64-cross

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -7,7 +7,6 @@ on:
       - '*'
 
 jobs:
-
   binary_linux_amd64:
     runs-on: ubuntu-latest
     steps:
@@ -19,24 +18,8 @@ jobs:
             source "$HOME/.cargo/env"
             rustup toolchain install nightly
             rustup default nightly
-            cargo build --release -p data-avail
-            mv target/release/data-avail target/release/data-avail-linux-amd64
-         - uses: actions/upload-artifact@v2
-           with:
-             name: data-avail-linux-amd64-binary
-             path: target/release/data-avail-linux-amd64
+            rustup target add wasm32-unknown-unknown
 
-  binary_linux_amd64_tar:
-    runs-on: ubuntu-latest
-    steps:
-         - uses: actions/checkout@v2
-         - name: install cargo deps and build avail
-           shell: bash
-           run: |
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-            source "$HOME/.cargo/env"
-            rustup toolchain install nightly
-            rustup default nightly
             cargo build --release -p data-avail
             mv target/release/data-avail target/release/data-avail-linux-amd64
             pushd target/release/
@@ -58,6 +41,7 @@ jobs:
             source "$HOME/.cargo/env"
             rustup toolchain install nightly
             rustup default nightly
+            rustup target add wasm32-unknown-unknown
 
             rustup target add aarch64-unknown-linux-gnu
             sudo apt-get update && sudo apt-get install -y musl-tools clang gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev libc6-dev-arm64-cross
@@ -74,12 +58,9 @@ jobs:
 
   # compile all binaries from previous jobs into single release
   binary_publish:
-    needs: [binary_linux_amd64, binary_linux_amd64_tar, binary_linux_aarch64]
+    needs: [binary_linux_amd64, binary_linux_aarch64]
     runs-on: ubuntu-latest
     steps:
-         - uses: actions/download-artifact@v2
-           with:
-             name: data-avail-linux-amd64-binary
          - uses: actions/download-artifact@v2
            with:
              name: data-avail-linux-amd64-tar
@@ -94,7 +75,7 @@ jobs:
          - name: publish binaries
            uses: svenstaro/upload-release-action@v2
            with:
-             repo_token: ${{ secrets.PAT_TOKEN }}
+             repo_token: ${{ secrets.GITHUB_TOKEN }}
              file: /home/runner/work/avail/avail/data-avail*
              release_name: ${{ steps.prepare.outputs.tag_name }}
              tag: ${{ steps.prepare.outputs.tag_name }}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -18,7 +18,7 @@ jobs:
             source "$HOME/.cargo/env"
             rustup toolchain install nightly
             rustup default nightly
-            rustup target add wasm32-unknown-unknown
+            rustup target add wasm32-unknown-unknown --toolchain nightly
 
             cargo build --release -p data-avail
             mv target/release/data-avail target/release/data-avail-linux-amd64
@@ -41,7 +41,7 @@ jobs:
             source "$HOME/.cargo/env"
             rustup toolchain install nightly
             rustup default nightly
-            rustup target add wasm32-unknown-unknown
+            rustup target add wasm32-unknown-unknown --toolchain nightly
 
             rustup target add aarch64-unknown-linux-gnu
             sudo apt-get update && sudo apt-get install -y musl-tools clang gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev libc6-dev-arm64-cross

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,57 @@
+name: Security CI
+on: [push, pull_request]
+
+jobs:
+  check:
+    name: "Check"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: "actions-rs/toolchain@v1"
+        with:
+          override: true
+          profile: "minimal"
+          toolchain: "stable"
+      - uses: "actions-rs/cargo@v1"
+        with:
+          command: "check"
+
+  fmt:
+    name: "Rustfmt"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: "actions-rs/toolchain@v1"
+        with:
+          override: true
+          profile: "minimal"
+          toolchain: "nightly"
+      - run: "rustup component add rustfmt"
+      - uses: "actions-rs/cargo@v1"
+        with:
+          command: "fmt"
+          args: "--all -- --check"
+
+  clippy:
+    name: "Clippy"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: "actions-rs/toolchain@v1"
+        with:
+          override: true
+          profile: "minimal"
+          toolchain: "nightly"
+      - run: "rustup component add clippy"
+      - uses: "actions-rs/cargo@v1"
+        with:
+          command: "clippy"
+          args: "-- -D warnings"
+
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/audit-check@v1.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Polygon Technology Security Information
+
+## Link to vulnerability disclosure details (Bug Bounty)
+- Websites and Applications: https://hackerone.com/polygon-technology
+- Smart Contracts: https://immunefi.com/bounty/polygon
+
+## Languages that our team speaks and understands.
+Preferred-Languages: en
+
+## Security-related job openings at Polygon.
+https://polygon.technology/careers
+
+## Polygon security contact details
+security@polygon.technology
+

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,10 @@
+binop_separator = "Back"
+comment_width = 120
+imports_granularity = "Crate"
+max_width = 120
+reorder_imports = true
+tab_spaces = 4
+trailing_semicolon = true
+use_small_heuristics = "Max"
+use_field_init_shorthand = true
+wrap_comments = true


### PR DESCRIPTION
The current build process was failing and required use of the nightly toolchain. I'm switching to the nightly tool chain in the CI flow and also committing some standard Rust CI workflows from @cvhpoly.

There is  a successful run here: https://github.com/maticnetwork/avail/actions/runs/3431455773

That run created this release: https://github.com/maticnetwork/avail/releases/tag/v1.3.0-2-ad405d0