### PR TITLE
Add kate rows RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "da-primitives"
 version = "0.4.2"
-source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.2#d94ec5cb79aee3e6eb2c93235b44a08b7ce69450"
+source = "git+https://github.com/maticnetwork/avail-core?tag=kate-recovery/v0.8.0#4c32cbeaf24abd7707a104b3f1e89679c0d7462e"
 dependencies = [
  "beefy-merkle-tree",
  "derive_more",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "data-avail"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "clap 4.0.29",
  "clap_complete",
@@ -3678,8 +3678,8 @@ dependencies = [
 
 [[package]]
 name = "kate"
-version = "0.5.3"
-source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.2#d94ec5cb79aee3e6eb2c93235b44a08b7ce69450"
+version = "0.6.0"
+source = "git+https://github.com/maticnetwork/avail-core?tag=kate-recovery/v0.8.0#4c32cbeaf24abd7707a104b3f1e89679c0d7462e"
 dependencies = [
  "da-primitives",
  "derive_more",
@@ -3705,8 +3705,8 @@ dependencies = [
 
 [[package]]
 name = "kate-recovery"
-version = "0.7.1"
-source = "git+https://github.com/maticnetwork/avail-core?tag=da-primitives/v0.4.2#d94ec5cb79aee3e6eb2c93235b44a08b7ce69450"
+version = "0.8.0"
+source = "git+https://github.com/maticnetwork/avail-core?tag=kate-recovery/v0.8.0#4c32cbeaf24abd7707a104b3f1e89679c0d7462e"
 dependencies = [
  "dusk-bytes",
  "dusk-plonk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ frame-system-rpc-runtime-api = { path = "pallets/system/rpc/runtime-api" }
 frame-system-benchmarking = { path = "pallets/system/benchmarking" }
 
 # Polygon Primitives
-da-primitives = { git="https://github.com/maticnetwork/avail-core", version = "0.4.2", tag = "da-primitives/v0.4.2" }
-kate = { git="https://github.com/maticnetwork/avail-core", version = "0.5.3", tag = "da-primitives/v0.4.2" }
-kate-recovery = { git="https://github.com/maticnetwork/avail-core", version = "0.7.1", tag = "da-primitives/v0.4.2" }
+da-primitives = { git="https://github.com/maticnetwork/avail-core", version = "0.4.2", tag = "kate-recovery/v0.8.0" }
+kate = { git="https://github.com/maticnetwork/avail-core", version = "0.6.0", tag = "kate-recovery/v0.8.0" }
+kate-recovery = { git="https://github.com/maticnetwork/avail-core", version = "0.8.0", tag = "kate-recovery/v0.8.0" }
 
 
 # Nomad

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 
 [dependencies]
 afl = "*"
-kate-recovery = "0.7" 
-kate = "0.5" 
+kate-recovery = "0.8" 
+kate = "0.6" 
 da-primitives = "0.4"
 hex-literal = "0.3.1"
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-avail"
-version = "1.4.0"
+version = "1.5.0"
 description = "Polygon Data Avilability Node."
 authors = ["Anonymous"]
 homepage = "https://polygon.technology/"
@@ -19,7 +19,7 @@ name = "data-avail"
 [dependencies]
 # Internals
 da-primitives = { version = "0.4", default-features = false }
-kate = { version = "0.5", default-features = false }
+kate = { version = "0.6", default-features = false }
 da-runtime = { path = "../runtime" }
 da-control = { path = "../pallets/dactr" }
 kate-rpc = { path = "../rpc/kate-rpc" }

--- a/pallets/dactr/Cargo.toml
+++ b/pallets/dactr/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 da-primitives = { version = "0.4", default-features = false }
-kate = { version = "0.5", default-features = false }
+kate = { version = "0.6", default-features = false }
 
 # Substrate
 serde = { version = "1.0.126", optional = true, features = ["derive"] }

--- a/pallets/mocked_runtime/Cargo.toml
+++ b/pallets/mocked_runtime/Cargo.toml
@@ -10,7 +10,7 @@ description = "Mokend Runtime for Testing"
 
 [dependencies]
 da-primitives = { version = "0.4", default-features = false }
-kate = { version = "0.5", default-features = false }
+kate = { version = "0.6", default-features = false }
 da-control = { path = "../dactr" }
 
 scale-info = { version = "2.1.1", features = ["derive"] }

--- a/pallets/system/Cargo.toml
+++ b/pallets/system/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 da-primitives = { version = "0.4", default-features = false }
-kate = { version = "0.5", default-features = false }
+kate = { version = "0.6", default-features = false }
 
 # Other
 impl-trait-for-tuples = "0.2.1"

--- a/rpc/kate-rpc/Cargo.toml
+++ b/rpc/kate-rpc/Cargo.toml
@@ -17,8 +17,8 @@ rs_merkle = { version = "1.2.0", default-features = false }
 
 codec = { package = "parity-scale-codec", version = "3" }
 da-primitives = { version = "0.4", default-features = false }
-kate = { version = "0.5", default-features = false }
-kate-recovery = { version = "0.7", default-features = false }
+kate = { version = "0.6", default-features = false }
+kate-recovery = { version = "0.8", default-features = false }
 jsonrpsee = { version = "0.15.1", features = ["server", "client"] }
 
 frame-system-rpc-runtime-api = "4.0.0-dev"

--- a/rpc/kate-rpc/src/lib.rs
+++ b/rpc/kate-rpc/src/lib.rs
@@ -160,18 +160,19 @@ where
 			.block(&block_id)
 			.map_err(|e| internal_err!("Invalid block number: {:?}", e))?
 			.ok_or_else(|| internal_err!("Missing block {}", block_id))?;
+
 		let block_hash = signed_block.block.header().hash();
+
+		if self.client.info().finalized_number < *signed_block.block.header().number() {
+			return Err(internal_err!(
+				"Requested block {block_hash} is not finalized"
+			));
+		}
 
 		let mut block_ext_cache = self
 			.block_ext_cache
 			.write()
 			.map_err(|_| internal_err!("Block cache lock is poisoned .qed"))?;
-
-		let block_length: BlockLength = self
-			.client
-			.runtime_api()
-			.get_block_length(&block_id)
-			.map_err(|e| internal_err!("Block Length cannot be fetched: {:?}", e))?;
 
 		if !block_ext_cache.contains(&block_hash) {
 			// build block data extension and cache it
@@ -191,6 +192,12 @@ where
 				.runtime_api()
 				.get_babe_vrf(&block_id)
 				.map_err(|e| internal_err!("Babe VRF not found for block {}: {:?}", block_id, e))?;
+
+			let block_length: BlockLength =
+				self.client
+					.runtime_api()
+					.get_block_length(&block_id)
+					.map_err(|e| internal_err!("Block Length cannot be fetched: {:?}", e))?;
 
 			let (_, block, block_dims) = kate::com::flatten_and_pad_block(
 				block_length.rows,
@@ -231,18 +238,19 @@ where
 			.block(&block_id)
 			.map_err(|e| internal_err!("Invalid block number: {:?}", e))?
 			.ok_or_else(|| internal_err!("Missing block {}", block_id))?;
+
 		let block_hash = signed_block.block.header().hash();
+
+		if self.client.info().finalized_number < *signed_block.block.header().number() {
+			return Err(internal_err!(
+				"Requested block {block_hash} is not finalized"
+			));
+		}
 
 		let mut block_ext_cache = self
 			.block_ext_cache
 			.write()
 			.map_err(|_| internal_err!("Block cache lock is poisoned .qed"))?;
-
-		let block_length: BlockLength = self
-			.client
-			.runtime_api()
-			.get_block_length(&block_id)
-			.map_err(|e| internal_err!("Block Length cannot be fetched: {:?}", e))?;
 
 		if !block_ext_cache.contains(&block_hash) {
 			// build block data extension and cache it
@@ -255,6 +263,12 @@ where
 					data: e.encode(),
 				})
 				.collect();
+
+			let block_length: BlockLength =
+				self.client
+					.runtime_api()
+					.get_block_length(&block_id)
+					.map_err(|e| internal_err!("Block Length cannot be fetched: {:?}", e))?;
 
 			// Use Babe's VRF
 			let seed: [u8; 32] = self
@@ -315,18 +329,19 @@ where
 			.block(&block_id)
 			.map_err(|e| internal_err!("Invalid block number: {:?}", e))?
 			.ok_or_else(|| internal_err!("Missing block {}", block_id))?;
+
 		let block_hash = signed_block.block.header().hash();
+
+		if self.client.info().finalized_number < *signed_block.block.header().number() {
+			return Err(internal_err!(
+				"Requested block {block_hash} is not finalized"
+			));
+		}
 
 		let mut block_ext_cache = self
 			.block_ext_cache
 			.write()
 			.map_err(|_| internal_err!("Block cache lock is poisoned .qed"))?;
-
-		let block_length: BlockLength = self
-			.client
-			.runtime_api()
-			.get_block_length(&block_id)
-			.map_err(|e| internal_err!("Block Length cannot be fetched: {:?}", e))?;
 
 		if !block_ext_cache.contains(&block_hash) {
 			// build block data extension and cache it
@@ -339,6 +354,12 @@ where
 					data: e.encode(),
 				})
 				.collect();
+
+			let block_length: BlockLength =
+				self.client
+					.runtime_api()
+					.get_block_length(&block_id)
+					.map_err(|e| internal_err!("Block Length cannot be fetched: {:?}", e))?;
 
 			// Use Babe's VRF
 			let seed: [u8; 32] = self

--- a/rpc/kate-rpc/src/lib.rs
+++ b/rpc/kate-rpc/src/lib.rs
@@ -39,6 +39,13 @@ where
 	Block: BlockT,
 	SDFilter: Filter<CallOf<Block>>,
 {
+	#[method(name = "kate_queryRows")]
+	fn query_rows(
+		&self,
+		rows: Vec<u32>,
+		at: Option<HashOf<Block>>,
+	) -> RpcResult<Vec<Option<Vec<u8>>>>;
+
 	#[method(name = "kate_queryAppData")]
 	fn query_app_data(
 		&self,
@@ -141,6 +148,77 @@ where
 	SDFilter: Filter<CallOf<Block>> + 'static,
 	<<Block as BlockT>::Extrinsic as Extrinsic>::Call: Clone,
 {
+	fn query_rows(
+		&self,
+		rows: Vec<u32>,
+		at: Option<HashOf<Block>>,
+	) -> RpcResult<Vec<Option<Vec<u8>>>> {
+		let block_id = self.block_id(at);
+
+		let signed_block = self
+			.client
+			.block(&block_id)
+			.map_err(|e| internal_err!("Invalid block number: {:?}", e))?
+			.ok_or_else(|| internal_err!("Missing block {}", block_id))?;
+		let block_hash = signed_block.block.header().hash();
+
+		let mut block_ext_cache = self
+			.block_ext_cache
+			.write()
+			.map_err(|_| internal_err!("Block cache lock is poisoned .qed"))?;
+
+		let block_length: BlockLength = self
+			.client
+			.runtime_api()
+			.get_block_length(&block_id)
+			.map_err(|e| internal_err!("Block Length cannot be fetched: {:?}", e))?;
+
+		if !block_ext_cache.contains(&block_hash) {
+			// build block data extension and cache it
+			let xts_by_id: Vec<AppExtrinsic> = signed_block
+				.block
+				.extrinsics()
+				.iter()
+				.map(|e| AppExtrinsic {
+					app_id: e.app_id(),
+					data: e.encode(),
+				})
+				.collect();
+
+			// Use Babe's VRF
+			let seed: [u8; 32] = self
+				.client
+				.runtime_api()
+				.get_babe_vrf(&block_id)
+				.map_err(|e| internal_err!("Babe VRF not found for block {}: {:?}", block_id, e))?;
+
+			let (_, block, block_dims) = kate::com::flatten_and_pad_block(
+				block_length.rows,
+				block_length.cols,
+				block_length.chunk_size(),
+				&xts_by_id,
+				seed,
+			)
+			.map_err(|e| internal_err!("Flatten and pad block failed: {:?}", e))?;
+
+			let data = kate::com::par_extend_data_matrix(block_dims, &block)
+				.map_err(|e| internal_err!("Matrix cannot be extended: {:?}", e))?;
+
+			block_ext_cache.put(block_hash, (data, block_dims));
+		}
+
+		let (ext_data, block_dims) = block_ext_cache
+			.get(&block_hash)
+			.ok_or_else(|| internal_err!("Block hash {} cannot be fetched", block_hash))?;
+
+		let dimensions: Dimensions = block_dims
+			.clone()
+			.try_into()
+			.map_err(|e| internal_err!("Invalid dimensions: {:?}", e))?;
+
+		Ok(kate::com::scalars_to_rows(&rows, &dimensions, ext_data))
+	}
+
 	fn query_app_data(
 		&self,
 		app_id: AppId,
@@ -220,7 +298,7 @@ where
 			.try_into()
 			.map_err(|e| internal_err!("Invalid dimensions: {:?}", e))?;
 
-		Ok(kate::com::scalars_to_rows(
+		Ok(kate::com::scalars_to_app_rows(
 			app_id.0,
 			&app_data_index,
 			&dimensions,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 # Internal
 da-primitives = { version = "0.4", default-features = false }
-kate = { version = "0.5" , default-features = false }
+kate = { version = "0.6" , default-features = false }
 da-control = { path = "../pallets/dactr", default-features = false }
 kate-rpc-runtime-api = { path = "../rpc/kate-rpc-runtime-api", default-features = false }
 


### PR DESCRIPTION
This PR adds `queryRows` RPC to support fetching and pushing rows to DHT on light clients. Since new RPC is added, node version is increased from 1.4.0 to 1.5.0. Dependency to avail-core will be updated once corresponding PR is merged.